### PR TITLE
Add baski.agents LLM agent framework

### DIFF
--- a/baski/agents/CLAUDE.md
+++ b/baski/agents/CLAUDE.md
@@ -1,0 +1,53 @@
+# Agent Framework
+
+Agentic framework for building LLM agents with tool use, built on Anthropic's Claude API.
+Ported from clarity-auto-care; the generic core lives here so other projects (e.g. nisse) reuse it.
+
+## Core Components
+
+- `Agent`: Main agent loop — streaming responses, parallel tool execution, conversation flow. Creates `ToolBox` internally. Auto-injects `KnowledgeTool` and `DeleteMessagesTool`.
+- `ToolBox`: Registry + parallel executor (`asyncio.gather`) for a set of tools.
+- `Tool`: Abstract base — define `name`, `one_line`, `description`, `input_schema`, implement `async execute(**kwargs) -> str`.
+- `MessageHistory`: Conversation history with context-window truncation (64k tokens default, truncates at 90%).
+- `TraceCollector` (`trace.py`): Persists turn-by-turn traces to GCS (gzipped JSON) + a Mongo `traces` summary collection.
+- `AgentExecuteResult`: Pydantic result (trace id, tokens, turn/tool counts, cost).
+
+## Built-in Tools (`tools/`)
+
+Auto-injected by `Agent`:
+- `KnowledgeTool` (`store_knowledge`): preserve facts across context truncation.
+- `DeleteMessagesTool` (`delete_messages`): drop turns by id to free context.
+
+Opt-in, generic (pass via `AgentConfig.tools`):
+- `GoogleSearchTool`, `YelpSearchTool`, `GooglePlayTool`, `AppleAppStoreTool` — via `baski.clients.serpapi_client`.
+- `WebBrowseTool` — via `baski.clients.playwright_client`.
+
+Project-specific tools (DB lookups, formatters) stay in the consuming project, NOT here.
+
+## Dependencies on baski
+
+Imports map to baski foundation: `baski.primitives.datetime`, `baski.primitives.json`,
+`baski.concurrent.as_async`, `baski.server.Logger`, `baski.clients.*`.
+
+## Usage
+
+```python
+from baski.agents import Agent, AgentConfig
+from baski.agents.tools import GoogleSearchTool
+
+config = AgentConfig(
+    logger=logger,
+    tools=[GoogleSearchTool(serpapi_client=serpapi_client)],
+    anthropic_client=anthropic_client,
+    database=database,          # pymongo AsyncDatabase — trace summaries
+    bucket_name="my-traces",    # GCS bucket for full traces (parameterized, no hardcoded default)
+    # model defaults to DEFAULT_MODEL ("claude-opus-4-8"); override per-agent if needed
+)
+result = await Agent(config=config).execute("user request")
+```
+
+## Notes
+
+- Tracing is mandatory: every `execute()` requires a Mongo `database` and a GCS `bucket_name`.
+- Extended thinking is `adaptive`; parallel tool use enabled; `max_tokens=128_000`.
+- The clarity FastAPI trace-browser router (`router.py` / `get_trace_flow.py`) was NOT ported — it is deployment-specific. Add a thin router in the consuming project if a trace UI is needed.

--- a/baski/agents/__init__.py
+++ b/baski/agents/__init__.py
@@ -1,0 +1,9 @@
+"""Agent framework for LLM-powered tool-use conversations."""
+
+from .agent import Agent, AgentConfig
+from .execute_result import AgentExecuteResult
+from .message_history import MessageHistory
+from .tool import Tool
+from .toolbox import ToolBox
+
+__all__ = ["Agent", "AgentConfig", "AgentExecuteResult", "MessageHistory", "Tool", "ToolBox"]

--- a/baski/agents/agent.py
+++ b/baski/agents/agent.py
@@ -1,0 +1,258 @@
+"""Core agentic loop with tool execution and conversation management."""
+
+import asyncio
+import time
+from typing import NamedTuple
+
+from anthropic import APIError as AnthropicAPIError
+from anthropic import APIStatusError, AsyncAnthropic
+from anthropic.types import Message, MessageParam, TextBlock, TextBlockParam, ThinkingBlock, ToolUseBlock
+from pymongo.asynchronous.database import AsyncDatabase
+
+from baski.primitives import datetime
+from baski.server import Logger
+
+from .execute_result import AgentExecuteResult
+from .message_history import MessageHistory
+from .pricing import ExecutionStats
+from .tool import Tool
+from .toolbox import ToolBox
+from .tools import DeleteMessagesTool, KnowledgeTool
+from .trace import TraceCollector, TraceCollectorConfig
+
+DEFAULT_MODEL = "claude-opus-4-8"
+
+
+class ParsedResponse(NamedTuple):
+    """Parsed content blocks from an Anthropic API response."""
+
+    tool_calls: list[ToolUseBlock]
+    text_blocks: list[TextBlock]
+
+
+class TurnResult(NamedTuple):
+    """Result of a single agentic turn."""
+
+    message_to_user: str | None
+    has_tool_calls: bool
+
+
+class AgentConfig(NamedTuple):
+    """Configuration parameters for Agent initialization."""
+
+    logger: Logger
+    tools: list[Tool]
+    anthropic_client: AsyncAnthropic
+    database: AsyncDatabase
+    bucket_name: str
+    model: str = DEFAULT_MODEL
+
+
+class Agent:
+    """Stateful agent with agentic loop handling tool execution and conversation management.
+
+    KnowledgeTool is automatically injected.
+    """
+
+    def __init__(self, config: AgentConfig, **params: object) -> None:
+        """Initialize agent with config and optional API parameter overrides."""
+        self.logger = config.logger
+        self.database = config.database
+        self.bucket_name = config.bucket_name
+        self.message_history = MessageHistory(logger=config.logger)
+        self.anthropic_client = config.anthropic_client
+
+        self.toolbox = ToolBox(logger=config.logger)
+        self.knowledge_tool = KnowledgeTool()
+        for tool in config.tools:
+            self.toolbox.add(tool)
+        self.toolbox.add(self.knowledge_tool)
+        self.toolbox.add(DeleteMessagesTool(self.message_history))
+
+        actual_system_prompt = (
+            f"You have tools:\n"
+            f"{self.toolbox.short_description()}\n"
+            f"\n"
+            f"IMPORTANT: Use store_knowledge tool proactively to preserve important information.\n"
+            f"Store knowledge immediately after learning new facts to prevent loss during conversation.\n"
+            f"\n"
+            f"CONTEXT MANAGEMENT: After storing knowledge, delete the source turns with delete_messages"
+            f" to free context space.\n"
+            f"Workflow: search → store_knowledge → delete_messages for the turns you just stored.\n"
+            f"\n"
+            f"Always use the most appropriate tool. Use parallel tool calls when they are independent\n"
+            f"Provide brief explanation of your reasoning for when you use tools and what are next steps."
+        )
+
+        self.params: dict[str, object] = {
+            "system": actual_system_prompt,
+            "model": config.model,
+            "tools": self.toolbox.format_for_api(),
+            "tool_choice": {"type": "auto", "disable_parallel_tool_use": False},
+            "thinking": {"type": "adaptive"},
+            "max_tokens": 128_000,
+        } | params
+
+    async def _call_api(self, messages: list[MessageParam]) -> Message:
+        """Streaming API call with retry on api_error (max 1 retry, 2s sleep)."""
+        max_retries = 1
+        retry_count = 0
+
+        while retry_count <= max_retries:
+            try:
+                async with self.anthropic_client.messages.stream(
+                    messages=messages,
+                    **self.params,
+                ) as stream:
+                    return await stream.get_final_message()
+            except APIStatusError as e:
+                if retry_count < max_retries and "api_error" in str(e):
+                    retry_count += 1
+                    self.logger.warning(
+                        "Anthropic API error, retrying",
+                        labels={
+                            "retryCount": retry_count,
+                            "maxRetries": max_retries,
+                            "error": str(e),
+                        },
+                    )
+                    await asyncio.sleep(2)
+                    continue
+                raise
+            except AnthropicAPIError:
+                raise
+
+        raise RuntimeError("Unreachable: retry loop exited without return or raise")
+
+    def _parse_response(self, content_blocks: list[object]) -> ParsedResponse:
+        """Separate tool_use and text blocks, log thinking blocks."""
+        tool_calls: list[ToolUseBlock] = []
+        text_blocks: list[TextBlock] = []
+
+        for block in content_blocks:
+            if isinstance(block, ToolUseBlock):
+                tool_calls.append(block)
+            elif isinstance(block, ThinkingBlock):
+                self.logger.info("Thinking", labels={"thinking": block.thinking})
+            elif isinstance(block, TextBlock):
+                text_blocks.append(block)
+            else:
+                self.logger.warning("Unknown content block type", labels={"blockType": type(block).__name__})
+
+        return ParsedResponse(tool_calls=tool_calls, text_blocks=text_blocks)
+
+    def _build_messages(self, user_request_message: MessageParam) -> list[MessageParam]:
+        """Build the full message list for an API call."""
+        now = datetime.now()
+        time_message = MessageParam(
+            role="user",
+            content=[TextBlockParam(type="text", text=f"Current time: {now.strftime('%A, %B %d, %Y %I:%M %p %Z')}")],
+        )
+        return [
+            user_request_message,
+            time_message,
+            self.knowledge_tool.format_as_user_message(),
+            *self.message_history.format_for_api(),
+        ]
+
+    async def _execute_tools(
+        self, tool_calls: list[ToolUseBlock], stats: ExecutionStats, trace: TraceCollector
+    ) -> None:
+        """Execute tool calls and record results in history and trace."""
+        stats.tool_calls += len(tool_calls)
+        self.logger.info(
+            "Tools execution", labels={"toolCount": len(tool_calls), "tools": [tc.name for tc in tool_calls]}
+        )
+        tool_results = await self.toolbox.execute(tool_calls)
+        self.message_history.add_tool_results(tool_results)
+        trace.record_tool_results(tool_results, self.toolbox.last_timings)
+
+    def _collect_text(self, text_blocks: list[TextBlock]) -> str | None:
+        """Join text blocks into a single user-facing message string."""
+        if not text_blocks:
+            return None
+        message_to_user = "\n".join([b.text for b in text_blocks])
+        self.logger.info("Text received", labels={"message_to_user": message_to_user})
+        return message_to_user
+
+    async def _run_turn(
+        self, user_request_message: MessageParam, stats: ExecutionStats, trace: TraceCollector
+    ) -> TurnResult:
+        """Run a single agentic turn: build messages, call API, parse response, execute tools."""
+        messages = self._build_messages(user_request_message)
+        trace.start_turn(messages)
+
+        start = time.monotonic()
+        message = await self._call_api(messages)
+        api_duration_ms = int((time.monotonic() - start) * 1000)
+
+        stats.collect(message.usage)
+        if len(self.message_history) == 0 and message.usage.input_tokens > self.message_history.max_tokens // 2:
+            raise RuntimeError("Initial context is too large. Try to provide more LLM context.")
+
+        self.message_history.truncate(message.usage)
+        parsed = self._parse_response(message.content)
+        trace.record_response(message, api_duration_ms)
+
+        with self.message_history:
+            self.message_history.add_assistant(message.content)
+            if parsed.tool_calls:
+                await self._execute_tools(parsed.tool_calls, stats, trace)
+
+        trace.end_turn()
+        return TurnResult(
+            message_to_user=self._collect_text(parsed.text_blocks),
+            has_tool_calls=bool(parsed.tool_calls),
+        )
+
+    async def execute(self, user_request: str) -> AgentExecuteResult:
+        """Execute user request.
+
+        It can be called multiple times however the context is preserved. Each following
+        call will have context from previous calls.
+        """
+        user_request_message = MessageParam(
+            role="user", content=[TextBlockParam(type="text", text=f"YOUR TASK IS: {user_request}")]
+        )
+        self.logger.info("Agent execution started", labels={"userRequest": user_request[:100]})
+
+        stats = ExecutionStats(model=str(self.params["model"]))
+        trace = TraceCollector(
+            config=TraceCollectorConfig(
+                user_request=user_request,
+                model=str(self.params["model"]),
+                system_prompt=str(self.params["system"]),
+                bucket_name=self.bucket_name,
+                database=self.database,
+                logger=self.logger,
+            )
+        )
+
+        turn = TurnResult(message_to_user=None, has_tool_calls=False)
+        try:
+            while True:
+                turn = await self._run_turn(user_request_message, stats, trace)
+                if not turn.has_tool_calls:
+                    break
+        except Exception as e:
+            await trace.finalize(stats, error=str(e))
+            raise
+
+        self.logger.info(
+            "Agent execution complete",
+            labels={"userRequest": user_request[:100], "traceId": trace.id, **stats.for_logs().model_dump()},
+        )
+
+        result = AgentExecuteResult(
+            trace_id=trace.id,
+            response=turn.message_to_user,
+            total_input_tokens=stats.input_tokens,
+            total_output_tokens=stats.output_tokens,
+            turn_count=stats.turn_count,
+            tool_call_count=stats.tool_calls,
+            total_cost=stats.cost,
+        )
+
+        await trace.finalize(stats, result)
+
+        return result

--- a/baski/agents/agent.py
+++ b/baski/agents/agent.py
@@ -6,7 +6,7 @@ from typing import NamedTuple
 
 from anthropic import APIError as AnthropicAPIError
 from anthropic import APIStatusError, AsyncAnthropic
-from anthropic.types import Message, MessageParam, TextBlock, TextBlockParam, ThinkingBlock, ToolUseBlock
+from anthropic.types import ContentBlock, Message, MessageParam, TextBlock, TextBlockParam, ThinkingBlock, ToolUseBlock
 from pymongo.asynchronous.database import AsyncDatabase
 
 from baski.primitives import datetime
@@ -102,7 +102,7 @@ class Agent:
             try:
                 async with self.anthropic_client.messages.stream(
                     messages=messages,
-                    **self.params,
+                    **self.params,  # type: ignore[arg-type]  # params is a dynamic dict merged with caller overrides
                 ) as stream:
                     return await stream.get_final_message()
             except APIStatusError as e:
@@ -124,7 +124,7 @@ class Agent:
 
         raise RuntimeError("Unreachable: retry loop exited without return or raise")
 
-    def _parse_response(self, content_blocks: list[object]) -> ParsedResponse:
+    def _parse_response(self, content_blocks: list[ContentBlock]) -> ParsedResponse:
         """Separate tool_use and text blocks, log thinking blocks."""
         tool_calls: list[ToolUseBlock] = []
         text_blocks: list[TextBlock] = []

--- a/baski/agents/execute_result.py
+++ b/baski/agents/execute_result.py
@@ -1,0 +1,15 @@
+"""Result model returned by Agent.execute()."""
+
+from pydantic import BaseModel, Field
+
+
+class AgentExecuteResult(BaseModel):
+    """Result from Agent.execute() containing response and execution metrics."""
+
+    trace_id: str = Field(..., description="Trace ID for debugging — references the full trace in GCS")
+    response: str | None = Field(None, description="Final text response from the agent to the user")
+    total_input_tokens: int = Field(..., description="Total input tokens consumed across all API calls")
+    total_output_tokens: int = Field(..., description="Total output tokens consumed across all API calls")
+    turn_count: int = Field(..., description="Number of API calls (turns) in the agentic loop")
+    tool_call_count: int = Field(..., description="Total number of tool calls across all turns")
+    total_cost: float = Field(..., description="Total cost in USD for this execution")

--- a/baski/agents/message_history.py
+++ b/baski/agents/message_history.py
@@ -1,0 +1,143 @@
+"""Conversation history management with context-window truncation."""
+
+from dataclasses import dataclass, field
+from typing import Self
+
+from anthropic.types import ContentBlock, MessageParam, TextBlockParam, ToolResultBlockParam, Usage
+
+from baski.server.logger import Logger
+
+
+@dataclass
+class Turn:
+    """A single agentic turn grouping all messages exchanged in one round."""
+
+    id: int
+    messages: list[MessageParam] = field(default_factory=list)
+
+
+class MessageHistory:
+    """Ordered conversation history with automatic context-window truncation."""
+
+    def __init__(
+        self,
+        logger: Logger,
+        max_tokens: int = 64_000,
+        truncate_threshold: float = 0.9,
+        truncate_percentage: float = 0.3,
+    ) -> None:
+        """Initialize with configurable token limits and truncation policy."""
+        self.turns: list[Turn] = []
+        self.max_tokens = max_tokens
+        self.truncate_threshold = truncate_threshold
+        self.truncate_percentage = truncate_percentage
+        self.logger = logger
+        self._next_turn_id: int = 0
+        self._current_turn: Turn | None = None
+        self._last_input_tokens: int = 0
+
+    def __len__(self) -> int:
+        """Return the number of recorded turns."""
+        return len(self.turns)
+
+    def __enter__(self) -> Self:
+        """Begin a new turn, assigning the next sequential ID."""
+        self._next_turn_id += 1
+        self._current_turn = Turn(id=self._next_turn_id)
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        """Commit the current turn to history if it contains messages."""
+        if self._current_turn and self._current_turn.messages:
+            self.turns.append(self._current_turn)
+        self._current_turn = None
+
+    def add_assistant(self, content_blocks: list[ContentBlock]) -> None:
+        """Append an assistant message with the given content blocks to the current turn."""
+        self._current_turn.messages.append(
+            MessageParam(
+                role="assistant",
+                content=content_blocks,
+            )
+        )
+
+    def add_tool_results(self, results: list[ToolResultBlockParam]) -> None:
+        """Append a user message containing tool results to the current turn."""
+        self._current_turn.messages.append(
+            MessageParam(
+                role="user",
+                content=results,
+            )
+        )
+
+    def add_user_text(self, text: str) -> None:
+        """Append a plain-text user message to the current turn."""
+        self._current_turn.messages.append(
+            MessageParam(
+                role="user",
+                content=[TextBlockParam(type="text", text=text)],
+            )
+        )
+
+    def format_for_api(self) -> list[MessageParam]:
+        """Return messages ready for API with [Turn N] markers on user messages."""
+        result = []
+        for turn in self.turns:
+            result.append(MessageParam(role="user", content=[TextBlockParam(type="text", text=f"[Turn {turn.id}]")]))
+            result.extend(turn.messages)
+
+        if self._last_input_tokens:
+            pct = int(self._last_input_tokens / self.max_tokens * 100)
+            result.append(
+                MessageParam(
+                    role="user",
+                    content=[
+                        TextBlockParam(
+                            type="text",
+                            text=(
+                                f"[Context: {pct}% used"
+                                f" — {self.max_tokens - self._last_input_tokens:,} tokens remaining]"
+                            ),
+                        )
+                    ],
+                )
+            )
+
+        return result
+
+    def delete_turns(self, turn_ids: list[int]) -> int:
+        """Remove entire turns by ID."""
+        ids_to_remove = set(turn_ids)
+        original = len(self.turns)
+        self.turns = [t for t in self.turns if t.id not in ids_to_remove]
+        removed = original - len(self.turns)
+        self.logger.info(
+            "Messages deleted by agent",
+            labels={
+                "turnIds": sorted(ids_to_remove),
+                "turnsRemoved": removed,
+            },
+        )
+        return removed
+
+    def truncate(self, usage: Usage) -> None:
+        """Remove the oldest turns when threshold exceeded."""
+        self._last_input_tokens = usage.input_tokens
+        if usage.input_tokens < int(self.max_tokens * self.truncate_threshold) or not self.turns:
+            return
+
+        turns_to_remove = max(int(len(self.turns) * self.truncate_percentage), 1)
+        initial_count = len(self.turns)
+        self.turns = self.turns[turns_to_remove:]
+
+        self.logger.info(
+            "Truncated message history",
+            labels={
+                "inputTokens": usage.input_tokens,
+                "maxTokens": self.max_tokens,
+                "threshold": self.max_tokens * self.truncate_threshold,
+                "turnsRemoved": initial_count - len(self.turns),
+                "turnsBefore": initial_count,
+                "turnsAfter": len(self.turns),
+            },
+        )

--- a/baski/agents/message_history.py
+++ b/baski/agents/message_history.py
@@ -52,9 +52,16 @@ class MessageHistory:
             self.turns.append(self._current_turn)
         self._current_turn = None
 
+    @property
+    def _turn(self) -> Turn:
+        """Return the active turn, raising if used outside the context manager."""
+        if self._current_turn is None:
+            raise RuntimeError("No active turn; use MessageHistory as a context manager first")
+        return self._current_turn
+
     def add_assistant(self, content_blocks: list[ContentBlock]) -> None:
         """Append an assistant message with the given content blocks to the current turn."""
-        self._current_turn.messages.append(
+        self._turn.messages.append(
             MessageParam(
                 role="assistant",
                 content=content_blocks,
@@ -63,7 +70,7 @@ class MessageHistory:
 
     def add_tool_results(self, results: list[ToolResultBlockParam]) -> None:
         """Append a user message containing tool results to the current turn."""
-        self._current_turn.messages.append(
+        self._turn.messages.append(
             MessageParam(
                 role="user",
                 content=results,
@@ -72,7 +79,7 @@ class MessageHistory:
 
     def add_user_text(self, text: str) -> None:
         """Append a plain-text user message to the current turn."""
-        self._current_turn.messages.append(
+        self._turn.messages.append(
             MessageParam(
                 role="user",
                 content=[TextBlockParam(type="text", text=text)],

--- a/baski/agents/pricing.py
+++ b/baski/agents/pricing.py
@@ -1,0 +1,92 @@
+"""Anthropic API pricing for cost calculation."""
+
+from dataclasses import dataclass
+
+from anthropic.types import Usage
+from pydantic import BaseModel
+
+# Pricing in USD per million tokens
+# Source: https://www.anthropic.com/pricing
+MODEL_PRICING = {
+    "claude-opus-4-8": {
+        "input": 5.00,  # $5 per million input tokens
+        "output": 25.00,  # $25 per million output tokens
+    },
+    "claude-opus-4-6": {
+        "input": 5.00,  # $5 per million input tokens
+        "output": 25.00,  # $25 per million output tokens
+    },
+    "claude-opus-4-5": {
+        "input": 5.00,  # $5 per million input tokens
+        "output": 25.00,  # $25 per million output tokens
+    },
+    "claude-sonnet-4-5": {
+        "input": 3.00,  # $3 per million input tokens
+        "output": 15.00,  # $15 per million output tokens
+    },
+    "claude-haiku-4-5": {
+        "input": 1.00,  # $1 per million input tokens
+        "output": 5.00,  # $5 per million output tokens
+    },
+}
+
+
+def calculate_cost(model: str, input_tokens: int, output_tokens: int) -> float:
+    """Calculate cost in USD for a given model and token usage.
+
+    Args:
+        model: Model name (e.g., "claude-sonnet-4-5")
+        input_tokens: Number of input tokens
+        output_tokens: Number of output tokens
+
+    Returns:
+        Cost in USD
+
+    """
+    pricing = MODEL_PRICING.get(model, MODEL_PRICING["claude-sonnet-4-5"])
+
+    input_cost = (input_tokens / 1_000_000) * pricing["input"]
+    output_cost = (output_tokens / 1_000_000) * pricing["output"]
+
+    return input_cost + output_cost
+
+
+class ExecutionLogFields(BaseModel):
+    """Structured log labels for agent execution summary."""
+
+    total_input_tokens: int
+    total_output_tokens: int
+    total_tokens: int
+    turn_count: int
+    tool_call_count: int
+    total_cost: str
+
+
+@dataclass
+class ExecutionStats:
+    """Tracks token usage, costs, and turn counts across an agent execution."""
+
+    model: str
+    input_tokens: int = 0
+    output_tokens: int = 0
+    turn_count: int = 0
+    tool_calls: int = 0
+    cost: float = 0.0
+
+    def collect(self, usage: Usage) -> None:
+        """Accumulate token usage and cost from a single API response."""
+        self.input_tokens += usage.input_tokens
+        self.output_tokens += usage.output_tokens
+        self.turn_count += 1
+        self.cost += calculate_cost(self.model, usage.input_tokens, usage.output_tokens)
+
+    def for_logs(self) -> ExecutionLogFields:
+        """Build a structured log-fields model from current execution stats."""
+        return ExecutionLogFields(
+            total_input_tokens=self.input_tokens,
+            total_output_tokens=self.output_tokens,
+            total_tokens=self.input_tokens + self.output_tokens,
+            turn_count=self.turn_count,
+            tool_call_count=self.tool_calls,
+            total_cost=f"${self.cost:.6f}",
+        )

--- a/baski/agents/tool.py
+++ b/baski/agents/tool.py
@@ -1,7 +1,7 @@
 """Abstract base class for all agent tools."""
 
 from abc import ABC, abstractmethod
-from typing import Any
+from typing import Any, ClassVar
 
 from anthropic.types import ToolParam
 
@@ -9,10 +9,10 @@ from anthropic.types import ToolParam
 class Tool(ABC):
     """Base class for all agent tools."""
 
-    name: str
-    one_line: str
-    description: str
-    input_schema: Any
+    name: ClassVar[str]
+    one_line: ClassVar[str]
+    description: ClassVar[str]
+    input_schema: ClassVar[Any]
 
     def __hash__(self) -> int:
         """Hash by tool name for use in sets and dicts."""

--- a/baski/agents/tool.py
+++ b/baski/agents/tool.py
@@ -1,0 +1,35 @@
+"""Abstract base class for all agent tools."""
+
+from abc import ABC, abstractmethod
+from typing import Any
+
+from anthropic.types import ToolParam
+
+
+class Tool(ABC):
+    """Base class for all agent tools."""
+
+    name: str
+    one_line: str
+    description: str
+    input_schema: Any
+
+    def __hash__(self) -> int:
+        """Hash by tool name for use in sets and dicts."""
+        return hash(self.name)
+
+    def __eq__(self, other: object) -> bool:
+        """Tools are equal if they share the same name."""
+        return isinstance(other, Tool) and self.name == other.name
+
+    def to_dict(self) -> ToolParam:
+        """Convert tool to Claude API format."""
+        return ToolParam(
+            name=self.name,
+            description=self.description,
+            input_schema=self.input_schema,
+        )
+
+    @abstractmethod
+    async def execute(self, **kwargs: object) -> str:
+        """Execute the tool with the given keyword arguments and return a string result."""

--- a/baski/agents/toolbox.py
+++ b/baski/agents/toolbox.py
@@ -1,0 +1,76 @@
+"""Registry and executor for all agent tools."""
+
+import asyncio
+import time
+
+from anthropic.types import ToolParam, ToolResultBlockParam, ToolUseBlock
+
+from baski.server import Logger
+
+from .tool import Tool
+
+
+class ToolBox:
+    """Registry and parallel executor for a named set of agent tools."""
+
+    def __init__(self, logger: Logger) -> None:
+        """Initialize an empty toolbox with a logger for error reporting."""
+        self._tools: dict[str, Tool] = {}
+        self.logger = logger
+        self.last_timings: dict[str, int] = {}
+
+    def __contains__(self, tool_name: str) -> bool:
+        """Return True if a tool with the given name is registered."""
+        return tool_name in self._tools
+
+    def add(self, tool: Tool) -> None:
+        """Add a tool to the toolbox."""
+        self._tools[tool.name] = tool
+
+    def get(self, tool_name: str) -> Tool | None:
+        """Get a tool from the toolbox by name."""
+        return self._tools.get(tool_name)
+
+    def remove(self, tool_name: str) -> None:
+        """Remove a tool from the toolbox by name."""
+        self._tools.pop(tool_name, None)
+
+    def short_description(self) -> str:
+        """Short description of tools in toolbox for LLM awareness."""
+        if not self._tools:
+            return "No tools available"
+
+        descriptions = []
+        for i, tool in enumerate(self._tools.values(), 1):
+            descriptions.append(f"{i}. {tool.one_line} ({tool.name})")
+
+        return "\n".join(descriptions)
+
+    def format_for_api(self) -> list[ToolParam]:
+        """Convert tools to Claude API format."""
+        return [tool.to_dict() for tool in self._tools.values()]
+
+    async def _execute_single(self, tool_call: ToolUseBlock) -> ToolResultBlockParam:
+        """Execute a single tool call with timing."""
+        tool_name = tool_call.name
+        tool_input = tool_call.input
+
+        if tool_name not in self._tools:
+            self.logger.error("Tool not found", labels={"toolName": tool_name})
+            self.last_timings[tool_call.id] = 0
+            return ToolResultBlockParam(
+                type="tool_result", tool_use_id=tool_call.id, content=f"Error: Tool {tool_name} not found"
+            )
+
+        tool = self._tools[tool_name]
+        start = time.monotonic()
+
+        result = await tool.execute(**tool_input)
+        self.last_timings[tool_call.id] = int((time.monotonic() - start) * 1000)
+        return ToolResultBlockParam(type="tool_result", tool_use_id=tool_call.id, content=result)
+
+    async def execute(self, tool_calls: list[ToolUseBlock]) -> list[ToolResultBlockParam]:
+        """Execute tool calls in parallel and return formatted results."""
+        self.last_timings = {}
+        results = await asyncio.gather(*[self._execute_single(tc) for tc in tool_calls])
+        return list(results)

--- a/baski/agents/tools/__init__.py
+++ b/baski/agents/tools/__init__.py
@@ -1,0 +1,19 @@
+"""Agent tool implementations."""
+
+from .apple_app_store import AppleAppStoreTool
+from .delete_messages import DeleteMessagesTool
+from .google_play import GooglePlayTool
+from .google_search import GoogleSearchTool
+from .knowledge import KnowledgeTool
+from .web_browse import WebBrowseTool
+from .yelp_search import YelpSearchTool
+
+__all__ = [
+    "AppleAppStoreTool",
+    "DeleteMessagesTool",
+    "GooglePlayTool",
+    "GoogleSearchTool",
+    "KnowledgeTool",
+    "WebBrowseTool",
+    "YelpSearchTool",
+]

--- a/baski/agents/tools/apple_app_store.py
+++ b/baski/agents/tools/apple_app_store.py
@@ -1,0 +1,89 @@
+"""Tool for fetching Apple App Store data via SerpApi."""
+
+from typing import Any, ClassVar
+
+from baski.clients.serpapi_client import SerpApiClient
+from baski.server import Logger
+
+from ..tool import Tool
+
+
+class AppleAppStoreTool(Tool):
+    """Tool for fetching Apple App Store data via SerpApi."""
+
+    name = "fetch_app_store_data"
+    one_line = "Fetch Apple App Store data"
+    description = (
+        "Fetch Apple App Store data by searching for company/app name. "
+        "Returns app information including title, rating, developer, and description."
+    )
+    input_schema: ClassVar[Any] = {
+        "type": "object",
+        "properties": {
+            "company_name": {"type": "string", "description": "Company or app name to search for (e.g., 'Zibra AI')"}
+        },
+        "required": ["company_name"],
+    }
+
+    def __init__(self, serpapi_client: SerpApiClient, logger: Logger) -> None:
+        """Store SerpApi client and logger."""
+        self.serpapi_client = serpapi_client
+        self.logger = logger
+
+    async def execute(self, company_name: str) -> str:  # type: ignore[override]
+        """Search App Store by company name and return formatted app details."""
+        product_id = await self._find_product_id(company_name)
+        if product_id is None:
+            return f"No App Store results found for '{company_name}'"
+
+        product_data = await self.serpapi_client.get_apple_product(product_id)
+        if not product_data:
+            return f"No App Store product data found for ID: {product_id}"
+
+        return self._format_product(product_data)
+
+    async def _find_product_id(self, company_name: str) -> str | None:
+        """Search App Store and return the first product ID found."""
+        search_results = await self.serpapi_client.search_apple_app_store(term=company_name)
+        if not search_results or not search_results.get("organic_results"):
+            return None
+        first_result = search_results["organic_results"][0]
+        if not isinstance(first_result, dict):
+            return None
+        return first_result.get("product_id")
+
+    def _format_product(self, product_data: dict) -> str:  # noqa: ANON002 — SerpAPI JSON response item, schema varies
+        """Format product data into a human-readable string."""
+        parts = []
+
+        title = product_data.get("title")
+        if title:
+            parts.append(f"# {title}\n")
+
+        developer = product_data.get("developer")
+        if developer:
+            parts.append(f"Developer: {developer}")
+
+        description = product_data.get("description")
+        if description:
+            parts.append(description)
+
+        details = self._collect_details(product_data)
+        if details:
+            parts.append("App Store: " + ", ".join(details))
+
+        return "\n\n".join(parts) if parts else "No relevant App Store data extracted"
+
+    def _collect_details(self, product_data: dict) -> list[str]:  # noqa: ANON002 — SerpAPI JSON response item, schema varies
+        """Collect App Store metadata detail strings."""
+        details = []
+        rating = product_data.get("rating")
+        if rating:
+            details.append(f"Rating: {rating:.1f}/5")
+        review_count = product_data.get("reviews")
+        if isinstance(review_count, int):
+            details.append(f"Reviews: {review_count:,}")
+        version = product_data.get("version")
+        if version:
+            details.append(f"Version: {version}")
+        return details

--- a/baski/agents/tools/delete_messages.py
+++ b/baski/agents/tools/delete_messages.py
@@ -1,0 +1,39 @@
+"""Tool for deleting conversation turns from message history."""
+
+from typing import Any, ClassVar
+
+from ..message_history import MessageHistory
+from ..tool import Tool
+
+
+class DeleteMessagesTool(Tool):
+    """Tool for agent to delete specific messages from conversation history."""
+
+    name = "delete_messages"
+    one_line = "Delete old messages to free context window"
+    description = """Delete turns from conversation history by [Turn N] IDs visible in messages.
+
+Use after store_knowledge to remove turns whose content is already preserved.
+Old search results may contain outdated info — delete to avoid misleading context.
+Tool result turns are the largest — prioritize deleting those."""
+
+    input_schema: ClassVar[Any] = {
+        "type": "object",
+        "properties": {
+            "turn_ids": {
+                "type": "array",
+                "items": {"type": "integer"},
+                "description": "Turn IDs to delete (visible as [Turn N] in messages)",
+            }
+        },
+        "required": ["turn_ids"],
+    }
+
+    def __init__(self, message_history: MessageHistory) -> None:
+        """Store reference to the shared message history."""
+        self.message_history = message_history
+
+    async def execute(self, turn_ids: list[int]) -> str:  # type: ignore[override]
+        """Delete specified turns and return removal count."""
+        removed = self.message_history.delete_turns(turn_ids)
+        return f"Deleted {removed} message(s). Remaining: {len(self.message_history)} messages."

--- a/baski/agents/tools/google_play.py
+++ b/baski/agents/tools/google_play.py
@@ -1,0 +1,78 @@
+"""Tool for fetching Google Play developer app data via SerpApi."""
+
+from typing import Any, ClassVar
+
+from baski.clients.serpapi_client import SerpApiClient
+from baski.server import Logger
+
+from ..tool import Tool
+
+
+class GooglePlayTool(Tool):
+    """Tool for fetching Google Play developer apps via SerpApi."""
+
+    name = "fetch_google_play_data"
+    one_line = "Fetch Google Play developer apps"
+    description = (
+        "Fetch Google Play developer apps and data using developer ID. Returns list of apps published by the developer."
+    )
+    input_schema: ClassVar[Any] = {
+        "type": "object",
+        "properties": {
+            "developer_id": {
+                "type": "string",
+                "description": "Google Play developer ID (e.g., 'Zibra+AI' or 'com.developer.name')",
+            }
+        },
+        "required": ["developer_id"],
+    }
+
+    def __init__(self, serpapi_client: SerpApiClient, logger: Logger) -> None:
+        """Store SerpApi client and logger."""
+        self.serpapi_client = serpapi_client
+        self.logger = logger
+
+    async def execute(self, developer_id: str) -> str:  # type: ignore[override]
+        """Fetch Google Play data for a developer and return formatted result."""
+        result = await self.serpapi_client.search_google_play(developer_id)
+
+        if not result:
+            return f"No Google Play data found for developer: {developer_id}"
+
+        app_highlight = result.get("app_highlight")
+        if not app_highlight:
+            return f"No featured app found for developer: {developer_id}"
+
+        return self._format_app(app_highlight)
+
+    def _format_app(self, app_highlight: dict) -> str:  # noqa: ANON002 — SerpAPI JSON response item, schema varies
+        """Format a Google Play app highlight into a human-readable string."""
+        parts = []
+
+        title = app_highlight.get("title")
+        if title:
+            parts.append(f"# {title}\n")
+
+        description = app_highlight.get("description")
+        if description:
+            parts.append(description)
+
+        details = self._collect_details(app_highlight)
+        if details:
+            parts.append("Google Play: " + ", ".join(details))
+
+        return "\n\n".join(parts) if parts else "No relevant Google Play data extracted"
+
+    def _collect_details(self, app_highlight: dict) -> list[str]:  # noqa: ANON002 — SerpAPI JSON response item, schema varies
+        """Collect Google Play metadata detail strings."""
+        details = []
+        rating = app_highlight.get("rating")
+        if rating:
+            details.append(f"Rating: {rating:.1f}/5")
+        review_count = app_highlight.get("reviews")
+        if review_count:
+            details.append(f"Reviews: {review_count:,}")
+        installs = app_highlight.get("installs")
+        if installs:
+            details.append(f"Installs: {installs}")
+        return details

--- a/baski/agents/tools/google_search.py
+++ b/baski/agents/tools/google_search.py
@@ -1,0 +1,86 @@
+"""Tool for searching the web via Google SerpApi."""
+
+from typing import Any, ClassVar
+
+from baski.clients.serpapi_client import SerpApiClient
+
+from ..tool import Tool
+
+
+class GoogleSearchTool(Tool):
+    """Tool for searching the web using Google via SerpApi."""
+
+    name = "google_search"
+    one_line = "Search Google for current information on any topic"
+    description = (
+        "Search Google for information. Use this when you need current information, facts, or data from the web. "
+        "Examples: Scope to a site with 'topic site:example.com', "
+        "use exact phrases with '\"exact phrase\"', "
+        "or combine terms with 'keyword1 keyword2 -exclude'"
+    )
+    input_schema: ClassVar[Any] = {
+        "type": "object",
+        "properties": {
+            "query": {
+                "type": "string",
+                "description": "The search query to execute on Google. Supports operators like site:, intitle:, inurl:",
+            }
+        },
+        "required": ["query"],
+    }
+
+    def __init__(self, serpapi_client: SerpApiClient) -> None:
+        """Store the SerpApi client."""
+        self.serpapi_client = serpapi_client
+
+    async def execute(self, query: str) -> str:  # type: ignore[override]
+        """Execute Google search and return formatted results."""
+        results = await self.serpapi_client.search_google(q=query)
+
+        lines = []
+
+        organic_results = results.get("organic_results", [])
+        if organic_results:
+            lines.append("Google Search Results:")
+            lines.append(self._format_organic_results(organic_results))
+
+        knowledge_graph = results.get("knowledge_graph")
+        if knowledge_graph:
+            lines.append("Google Knowledge Graph:")
+            lines.append(self._format_knowledge_graph(knowledge_graph))
+
+        answer_box = results.get("answer_box")
+        if answer_box:
+            lines.append("Google Direct Answer:")
+            lines.append(self._format_answer_box(answer_box))
+
+        return "\n\n".join(lines) if lines else f"No results found for query: {query}"
+
+    def _format_organic_results(self, organic_results: list[Any]) -> str:
+        """Format organic search results."""
+        lines = []
+        for i, result in enumerate(organic_results[:5], 1):
+            title = result.get("title", "No title")
+            snippet = result.get("snippet", "No description")
+            link = result.get("link", "")
+            lines.append(f"{i}. {title}\n   {snippet}\n   {link}")
+        return "\n".join(lines)
+
+    def _format_knowledge_graph(self, knowledge_graph: dict) -> str:  # noqa: ANON002 — SerpAPI JSON response item, schema varies
+        """Format knowledge graph information."""
+        lines = []
+        title = knowledge_graph.get("title", "")
+        description = knowledge_graph.get("description", "")
+        if title:
+            lines.append(f"  {title}")
+        if description:
+            lines.append(f"  {description}")
+        return "\n".join(lines)
+
+    def _format_answer_box(self, answer_box: dict) -> str:  # noqa: ANON002 — SerpAPI JSON response item, schema varies
+        """Format answer box information."""
+        lines = []
+        answer = answer_box.get("answer") or answer_box.get("snippet")
+        if answer:
+            lines.append(f"  {answer}")
+        return "\n".join(lines)

--- a/baski/agents/tools/knowledge.py
+++ b/baski/agents/tools/knowledge.py
@@ -1,0 +1,108 @@
+"""Tool for storing knowledge gathered during agent research."""
+
+from pathlib import Path
+from typing import Any, ClassVar
+
+from anthropic.types import MessageParam, TextBlockParam
+
+from ..tool import Tool
+
+
+class KnowledgeTool(Tool):
+    """Tool for agent to store knowledge gathered during conversation."""
+
+    name = "store_knowledge"
+    one_line = "Lightweight tool to preserve context (USE FREQUENTLY)"
+    description = """Store facts you discover during research to preserve them when conversation context gets truncated.
+
+CRITICAL: This is a lightweight, fast operation. Use it extensively.
+
+WHEN TO USE (frequently):
+- Immediately after extracting facts from any source
+- When you find conflicting information between sources
+- After every tool call that returns useful data
+- When noticing patterns, conflicts, or insights
+- After completing research on a specific topic (team, traction, market)
+- BEFORE you lose access to the information
+
+WHAT TO STORE:
+- Key facts, data points, and metrics from any source
+- Relationships and connections between entities
+- Observations, patterns, and discrepancies
+- Source attributions for critical claims
+- Context that might be needed later
+
+WHY THIS EXISTS:
+- Tool outputs disappear after a few turns
+- You need facts available to synthesize final reports later
+- Knowledge costs ~4k tokens vs 30k+ for keeping full sources
+
+FACT FORMULATION FORMAT: [SOURCE] entity + fact + temporal context
+
+GOOD EXAMPLES:
+- [WEB] Project X launched v2.0 in January 2024 with 3 new integrations
+- [LINKEDIN] Jane Smith - Senior Engineer at Acme Corp since March 2022
+- [DOCS] API rate limit is 1000 req/min for free tier, 10k for enterprise
+- [GOOGLE_PLAY] App has 100k+ downloads, 4.2 rating (523 reviews)
+- [CONFLICT] Docs say max 5 users, but pricing page says 10 users on free plan
+- [OBSERVATION] Library supports Python 3.10+ only, project uses 3.9
+
+BAD EXAMPLES:
+- "100k+ downloads" (which app? when checked?)
+- "Supports 3 languages" (which product? which languages?)
+- "Worked at Google" (who? how long?)
+- "Good documentation" (based on what? which sections?)
+
+Use aggressively - store first, synthesize later. More is better than perfect."""
+
+    input_schema: ClassVar[Any] = {
+        "type": "object",
+        "properties": {
+            "facts": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": "List of facts with [SOURCE] prefix. Example: '[DECK] Company founded 2020'",
+            }
+        },
+        "required": ["facts"],
+    }
+
+    def __init__(self) -> None:
+        """Initialize an empty knowledge store."""
+        self.knowledge: list[str] = []
+
+    async def execute(self, facts: list[str]) -> str:  # type: ignore[override]
+        """Store facts and return confirmation."""
+        self.knowledge.extend(facts)
+        stored = len(facts)
+        total = len(self.knowledge)
+        return f"Stored {stored} fact(s). Total: {total}. Now delete source turns with Tool: delete_messages."
+
+    def dump(self) -> None:
+        """Dump knowledge to markdown file (CLI only)."""
+        output_file = Path("knowledge.md")
+        content = "\n".join(f"- {k}" for k in self.knowledge)
+        output_file.write_text(content)
+
+    def get_knowledge(self) -> list[str]:
+        """Get all stored knowledge."""
+        return self.knowledge.copy()
+
+    def clear(self) -> None:
+        """Clear all stored knowledge."""
+        self.knowledge.clear()
+
+    def format_as_user_message(self) -> MessageParam:
+        """Format all knowledge as user message for API."""
+        parts = [f"IMPORTANT: Use {self.name} tool immediately after learning ANY new information to prevent loss.", ""]
+
+        if not self.knowledge:
+            parts.append("No knowledge stored yet.")
+        else:
+            parts.append("Knowledge:")
+            parts.extend(f"- {k}" for k in self.knowledge)
+
+        return MessageParam(
+            role="user",
+            content=[TextBlockParam(type="text", text="\n".join(parts))],
+        )

--- a/baski/agents/tools/web_browse.py
+++ b/baski/agents/tools/web_browse.py
@@ -1,0 +1,53 @@
+"""Tool for browsing websites and extracting page content as markdown."""
+
+from http import HTTPStatus
+from typing import Any, ClassVar
+
+from httpx import HTTPStatusError, TimeoutException
+
+from baski.clients.playwright_client import PlaywrightClient
+
+from ..tool import Tool
+
+_HTTP_FORBIDDEN = HTTPStatus.FORBIDDEN.value
+_HTTP_NOT_FOUND = HTTPStatus.NOT_FOUND.value
+
+
+class WebBrowseTool(Tool):
+    """Tool for browsing and extracting content from any website."""
+
+    name = "browse_website"
+    one_line = "Browse and extract content from any website"
+    description = (
+        "Fetch and read content from any website URL. Returns the page content as markdown. "
+        "Use this to read articles, documentation, company websites, or any web content."
+    )
+    input_schema: ClassVar[Any] = {
+        "type": "object",
+        "properties": {
+            "url": {"type": "string", "description": "The full URL to browse (e.g., 'https://example.com')"}
+        },
+        "required": ["url"],
+    }
+
+    def __init__(self, playwright_client: PlaywrightClient) -> None:
+        """Store the Playwright client for page fetching."""
+        self.playwright_client = playwright_client
+
+    async def execute(self, url: str) -> str:  # type: ignore[override]
+        """Fetch URL and return page content as markdown."""
+        try:
+            return await self.playwright_client.fetch_page_markdown(url)
+        except HTTPStatusError as e:
+            return self._handle_http_error(url=url, e=e)
+        except TimeoutException:
+            return f"Website timed out. Try again later: {url}"
+
+    def _handle_http_error(self, *, url: str, e: HTTPStatusError) -> str:
+        """Convert HTTP status errors to descriptive strings."""
+        status = e.response.status_code
+        if status == _HTTP_FORBIDDEN:
+            return f"Cannot access website (403 Forbidden). Website blocks automated access. URL: {url}"
+        if status == _HTTP_NOT_FOUND:
+            return f"Website not found (404). URL does not exist: {url}"
+        return f"Website returned HTTP {status}: {url}"

--- a/baski/agents/tools/yelp_search.py
+++ b/baski/agents/tools/yelp_search.py
@@ -1,0 +1,66 @@
+"""Tool for searching Yelp business listings via SerpApi."""
+
+from typing import Any, ClassVar
+
+from baski.clients.serpapi_client import SerpApiClient
+
+from ..tool import Tool
+
+
+class YelpSearchTool(Tool):
+    """Tool for searching Yelp businesses via SerpApi."""
+
+    name = "yelp_search"
+    one_line = "Search Yelp for local businesses"
+    description = (
+        "Search Yelp for local businesses by keyword and location. "
+        "Use this when you need to find restaurants, shops, services, or other local businesses. "
+        "Returns ratings, reviews, prices, categories, and links."
+    )
+    input_schema: ClassVar[Any] = {
+        "type": "object",
+        "properties": {
+            "query": {"type": "string", "description": "What to search for (e.g. 'auto repair', 'pizza', 'plumber')"},
+            "location": {
+                "type": "string",
+                "description": "Location to search in (e.g. 'San Francisco, CA', 'Belmont, CA')",
+            },
+        },
+        "required": ["query", "location"],
+    }
+
+    def __init__(self, serpapi_client: SerpApiClient) -> None:
+        """Store the SerpApi client."""
+        self.serpapi_client = serpapi_client
+
+    async def execute(self, query: str, location: str) -> str:  # type: ignore[override]
+        """Search Yelp and return formatted business listings."""
+        results = await self.serpapi_client.search_yelp(find_desc=query, find_loc=location)
+
+        organic = results.get("organic_results", [])
+        if not organic:
+            return f"No Yelp results found for '{query}' in {location}"
+
+        lines = [f"Yelp Results: {query} in {location}\n"]
+        for biz in organic:
+            lines.extend(self._format_business(biz))
+
+        return "\n".join(lines)
+
+    def _format_business(self, biz: dict) -> list[str]:  # noqa: ANON002 — SerpAPI JSON response item, schema varies
+        """Format a single Yelp business entry into display lines."""
+        lines = [f"- **{biz.get('title')}**"]
+        if biz.get("rating"):
+            lines.append(f"  - Rating: {biz['rating']} ({biz.get('reviews', 0)} reviews)")
+        if biz.get("price"):
+            lines.append(f"  - Price: {biz['price']}")
+        if biz.get("categories"):
+            cats = ", ".join(c.get("title", "") for c in biz["categories"] if isinstance(c, dict))
+            if cats:
+                lines.append(f"  - Categories: {cats}")
+        if biz.get("neighborhoods"):
+            lines.append(f"  - Neighborhoods: {', '.join(biz['neighborhoods'])}")
+        if biz.get("link"):
+            lines.append(f"  - Link: {biz['link']}")
+        lines.append("")
+        return lines

--- a/baski/agents/trace.py
+++ b/baski/agents/trace.py
@@ -1,0 +1,242 @@
+"""Agent trace collection and persistence to GCS and MongoDB."""
+
+import gzip
+import time
+import uuid
+from typing import NamedTuple
+
+from anthropic.types import Message, MessageParam, TextBlock, ThinkingBlock, ToolResultBlockParam, ToolUseBlock
+from google.api_core.exceptions import GoogleAPIError
+from google.cloud import storage
+from pydantic import BaseModel, ConfigDict, field_serializer
+from pymongo.asynchronous.database import AsyncDatabase
+
+from baski.concurrent import as_async
+from baski.primitives import datetime, json
+from baski.server import Logger
+
+from .execute_result import AgentExecuteResult
+from .pricing import ExecutionStats
+
+TRACES_PREFIX = "traces/"
+
+
+class TraceCollectorConfig(NamedTuple):
+    """Configuration for TraceCollector initialization."""
+
+    user_request: str
+    model: str
+    system_prompt: str
+    bucket_name: str
+    database: AsyncDatabase
+    logger: Logger
+
+
+class SerializedMessageContent(BaseModel):
+    """One content item within a serialized message."""
+
+    model_config = ConfigDict(extra="allow")
+
+
+class SerializedMessage(BaseModel):
+    """A message serialized for GCS trace storage."""
+
+    role: str
+    content: list[SerializedMessageContent | str]
+
+
+class ToolResultRecord(BaseModel):
+    """A single tool execution result for trace storage."""
+
+    tool_name: str
+    tool_id: str
+    output: str
+    is_error: bool
+    duration_ms: int
+
+
+class TurnRecord(BaseModel):
+    """Record of a single agentic turn for trace storage."""
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    turn_number: int
+    messages: list[MessageParam]
+    thinking: list[str] = []
+    text_response: str | None = None
+    tool_calls: list[ToolUseBlock] = []
+    tool_results: list[ToolResultRecord] = []
+    input_tokens: int = 0
+    output_tokens: int = 0
+    duration_ms: int = 0
+    stop_reason: str = ""
+
+    @field_serializer("messages")
+    @classmethod
+    def serialize_messages(cls, messages: list[MessageParam]) -> list[SerializedMessage]:
+        """Serialize messages to JSON-safe format."""
+        serialized = []
+        for msg in messages:
+            content = msg.get("content", [])
+            items = content if isinstance(content, list) else [content]
+            serialized.append(
+                SerializedMessage(
+                    role=msg["role"],
+                    content=[item.model_dump() if isinstance(item, BaseModel) else item for item in items],
+                )
+            )
+        return serialized
+
+
+class TraceRecord(BaseModel):
+    """Full execution trace record for GCS storage."""
+
+    id: str
+    created_at: str
+    user_request: str
+    model: str
+    system_prompt: str
+    turns: list[TurnRecord]
+    result: AgentExecuteResult | None
+    error: str | None
+
+
+class TraceCollector:
+    """Collects turn-by-turn trace data and persists to GCS and MongoDB."""
+
+    def __init__(self, config: TraceCollectorConfig) -> None:
+        """Initialize a new trace collector with a fresh UUID."""
+        self.id = str(uuid.uuid4())
+        self._user_request = config.user_request
+        self._model = config.model
+        self._system_prompt = config.system_prompt
+        self._bucket_name = config.bucket_name
+        self._database = config.database
+        self._logger = config.logger
+        self._turns: list[TurnRecord] = []
+        self._result: AgentExecuteResult | None = None
+        self._error: str | None = None
+        self._created_at = datetime.now().isoformat()
+        self._current_turn: TurnRecord | None = None
+        self._turn_start: float = 0
+
+    def start_turn(self, messages: list[MessageParam]) -> None:
+        """Begin recording a new turn."""
+        self._current_turn = TurnRecord(
+            turn_number=len(self._turns) + 1,
+            messages=messages,
+        )
+        self._turn_start = time.monotonic()
+
+    def record_response(self, message: Message, api_duration_ms: int) -> None:
+        """Record the API response content into the current turn."""
+        turn = self._current_turn
+        turn.input_tokens = message.usage.input_tokens
+        turn.output_tokens = message.usage.output_tokens
+        turn.stop_reason = message.stop_reason
+
+        for block in message.content:
+            if isinstance(block, ThinkingBlock):
+                turn.thinking.append(block.thinking)
+            elif isinstance(block, TextBlock):
+                if turn.text_response is None:
+                    turn.text_response = block.text
+                else:
+                    turn.text_response += "\n" + block.text
+            elif isinstance(block, ToolUseBlock):
+                turn.tool_calls.append(block)
+            else:
+                self._logger.warning("Unknown content block type", labels={"blockType": type(block).__name__})
+
+        _ = api_duration_ms  # recorded at turn level via end_turn timing
+
+    def record_tool_results(self, tool_results: list[ToolResultBlockParam], timings: dict[str, int]) -> None:
+        """Record tool execution results into the current turn."""
+        turn = self._current_turn
+        for result in tool_results:
+            tool_use_id = result["tool_use_id"]
+            content = result.get("content", "")
+            is_error = result.get("is_error", False)
+
+            tool_name = ""
+            for tc in turn.tool_calls:
+                if tc.id == tool_use_id:
+                    tool_name = tc.name
+                    break
+
+            turn.tool_results.append(
+                ToolResultRecord(
+                    tool_name=tool_name,
+                    tool_id=tool_use_id,
+                    output=content if isinstance(content, str) else str(content),
+                    is_error=is_error,
+                    duration_ms=timings.get(tool_use_id, 0),
+                )
+            )
+
+    def end_turn(self) -> None:
+        """Finalize the current turn and add it to the trace."""
+        self._current_turn.duration_ms = int((time.monotonic() - self._turn_start) * 1000)
+        self._turns.append(self._current_turn)
+        self._current_turn = None
+
+    async def finalize(
+        self, stats: ExecutionStats, result: AgentExecuteResult | None = None, error: str | None = None
+    ) -> None:
+        """Persist trace to GCS and MongoDB."""
+        if result is not None:
+            self._result = result
+        self._error = error
+
+        await self._upload_to_gcs()
+        await self._save_to_db(stats)
+
+    async def _upload_to_gcs(self) -> None:
+        upload_error: str | None = None
+        try:
+            record = TraceRecord(
+                id=self.id,
+                created_at=self._created_at,
+                user_request=self._user_request,
+                model=self._model,
+                system_prompt=self._system_prompt,
+                turns=self._turns,
+                result=self._result,
+                error=self._error,
+            )
+            json_bytes = json.dumps(record.model_dump(), indent=None, sort_keys=False).encode()
+            compressed = gzip.compress(json_bytes)
+
+            blob_name = f"{TRACES_PREFIX}{self.id}.json.gz"
+
+            def _upload() -> None:
+                client = storage.Client()
+                bucket = client.bucket(self._bucket_name)
+                blob = bucket.blob(blob_name)
+                blob.upload_from_string(compressed, content_type="application/gzip")
+
+            await as_async(_upload)
+        except (GoogleAPIError, OSError) as e:
+            upload_error = str(e)
+
+        if upload_error is not None:
+            self._logger.error("Failed to upload trace", labels={"traceId": self.id, "error": upload_error})
+        else:
+            self._logger.info("Trace uploaded", labels={"traceId": self.id})
+
+    async def _save_to_db(self, stats: ExecutionStats) -> None:
+        """Save lightweight trace summary to MongoDB."""
+        doc = {
+            "_id": self.id,
+            "created_at": self._created_at,
+            "user_request": self._user_request[:128],
+            "model": self._model,
+            "input_tokens": stats.input_tokens,
+            "output_tokens": stats.output_tokens,
+            "turn_count": stats.turn_count,
+            "tool_call_count": stats.tool_calls,
+            "cost": stats.cost,
+            "error": self._error,
+        }
+        await self._database["traces"].insert_one(doc)
+        self._logger.info("Trace saved to DB", labels={"traceId": self.id})

--- a/baski/agents/trace.py
+++ b/baski/agents/trace.py
@@ -3,7 +3,7 @@
 import gzip
 import time
 import uuid
-from typing import NamedTuple
+from typing import NamedTuple, cast
 
 from anthropic.types import Message, MessageParam, TextBlock, ThinkingBlock, ToolResultBlockParam, ToolUseBlock
 from google.api_core.exceptions import GoogleAPIError
@@ -82,7 +82,10 @@ class TurnRecord(BaseModel):
             serialized.append(
                 SerializedMessage(
                     role=msg["role"],
-                    content=[item.model_dump() if isinstance(item, BaseModel) else item for item in items],
+                    content=cast(
+                        "list[SerializedMessageContent | str]",
+                        [item.model_dump() if isinstance(item, BaseModel) else item for item in items],
+                    ),
                 )
             )
         return serialized
@@ -128,12 +131,19 @@ class TraceCollector:
         )
         self._turn_start = time.monotonic()
 
+    @property
+    def _turn(self) -> TurnRecord:
+        """Return the active turn, raising if no turn is in progress."""
+        if self._current_turn is None:
+            raise RuntimeError("No active turn; call start_turn first")
+        return self._current_turn
+
     def record_response(self, message: Message, api_duration_ms: int) -> None:
         """Record the API response content into the current turn."""
-        turn = self._current_turn
+        turn = self._turn
         turn.input_tokens = message.usage.input_tokens
         turn.output_tokens = message.usage.output_tokens
-        turn.stop_reason = message.stop_reason
+        turn.stop_reason = message.stop_reason or ""
 
         for block in message.content:
             if isinstance(block, ThinkingBlock):
@@ -152,7 +162,7 @@ class TraceCollector:
 
     def record_tool_results(self, tool_results: list[ToolResultBlockParam], timings: dict[str, int]) -> None:
         """Record tool execution results into the current turn."""
-        turn = self._current_turn
+        turn = self._turn
         for result in tool_results:
             tool_use_id = result["tool_use_id"]
             content = result.get("content", "")
@@ -176,8 +186,9 @@ class TraceCollector:
 
     def end_turn(self) -> None:
         """Finalize the current turn and add it to the trace."""
-        self._current_turn.duration_ms = int((time.monotonic() - self._turn_start) * 1000)
-        self._turns.append(self._current_turn)
+        turn = self._turn
+        turn.duration_ms = int((time.monotonic() - self._turn_start) * 1000)
+        self._turns.append(turn)
         self._current_turn = None
 
     async def finalize(
@@ -204,7 +215,7 @@ class TraceCollector:
                 result=self._result,
                 error=self._error,
             )
-            json_bytes = json.dumps(record.model_dump(), indent=None, sort_keys=False).encode()
+            json_bytes = json.dumps(record.model_dump(), sort_keys=False).encode()
             compressed = gzip.compress(json_bytes)
 
             blob_name = f"{TRACES_PREFIX}{self.id}.json.gz"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ license-files = ["LICENSE"]
 authors = [{ name = "Vladimir Baskakov" }]
 
 dependencies = [
+    "anthropic",
     "pyyaml",
     "python-dateutil",
     "pytz",

--- a/uv.lock
+++ b/uv.lock
@@ -160,6 +160,25 @@ wheels = [
 ]
 
 [[package]]
+name = "anthropic"
+version = "0.107.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "docstring-parser" },
+    { name = "httpx" },
+    { name = "jiter" },
+    { name = "pydantic" },
+    { name = "sniffio" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/f1/c6076a92e0bf6b0dfa126e213b3f9e8a510acd73567953210713aae6c256/anthropic-0.107.1.tar.gz", hash = "sha256:8e7169a6ab57fb806b778d9af018c867bad688144efec8969cdb4c5ccecd6670", size = 856312, upload-time = "2026-06-07T17:18:57.358Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/86/0e/71432f0777a263701955a23ebcc6650485c2753be9afbce2a6a8d72526e3/anthropic-0.107.1-py3-none-any.whl", hash = "sha256:b74338d08000ba105dfc8adae29af3713ece845a4bffec9986a20697e087c7b3", size = 838729, upload-time = "2026-06-07T17:18:58.729Z" },
+]
+
+[[package]]
 name = "anyio"
 version = "4.13.0"
 source = { registry = "https://pypi.org/simple" }
@@ -227,6 +246,7 @@ version = "0.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },
+    { name = "anthropic" },
     { name = "beautifulsoup4" },
     { name = "cryptography" },
     { name = "fastapi" },
@@ -268,6 +288,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "aiogram", specifier = ">=3" },
+    { name = "anthropic" },
     { name = "beautifulsoup4" },
     { name = "cryptography" },
     { name = "fastapi" },
@@ -584,6 +605,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/8c/8b/57666417c0f90f08bcafa776861060426765fdb422eb10212086fb811d26/dnspython-2.8.0.tar.gz", hash = "sha256:181d3c6996452cb1189c4046c61599b84a5a86e099562ffde77d26984ff26d0f", size = 368251, upload-time = "2025-09-07T18:58:00.022Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ba/5a/18ad964b0086c6e62e2e7500f7edc89e3faa45033c71c1893d34eed2b2de/dnspython-2.8.0-py3-none-any.whl", hash = "sha256:01d9bbc4a2d76bf0db7c1f729812ded6d912bd318d3b1cf81d30c0f845dbf3af", size = 331094, upload-time = "2025-09-07T18:57:58.071Z" },
+]
+
+[[package]]
+name = "docstring-parser"
+version = "0.18.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/4d/f332313098c1de1b2d2ff91cf2674415cc7cddab2ca1b01ae29774bd5fdf/docstring_parser-0.18.0.tar.gz", hash = "sha256:292510982205c12b1248696f44959db3cdd1740237a968ea1e2e7a900eeb2015", size = 29341, upload-time = "2026-04-14T04:09:19.867Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/5f/ed01f9a3cdffbd5a008556fc7b2a08ddb1cc6ace7effa7340604b1d16699/docstring_parser-0.18.0-py3-none-any.whl", hash = "sha256:b3fcbed555c47d8479be0796ef7e19c2670d428d72e96da63f3a40122860374b", size = 22484, upload-time = "2026-04-14T04:09:18.638Z" },
 ]
 
 [[package]]
@@ -1249,6 +1279,78 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "jiter"
+version = "0.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/66/b5/55f06bb281d92fb3cc86d14e1def2bd908bb77693183e7cb1f5a3c388b0c/jiter-0.15.0.tar.gz", hash = "sha256:4251acc80e2b7c9b7b8823456ea0fceeb0734dac2df7636d3c711b38476b5a76", size = 166640, upload-time = "2026-05-19T10:09:48.361Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/44/53/4f6bddbcde3c71e56d0aa1337ec95950f3d27dd4153e25aadf0feac71751/jiter-0.15.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:0e90a1c315a0226ec822d973817967f9223b7701546c8c2a7913e7ab0926294d", size = 308793, upload-time = "2026-05-19T10:07:35.25Z" },
+    { url = "https://files.pythonhosted.org/packages/01/84/c01099b59a285a1ebba64ae93f62bfa036675340fd1b0045ae65890a0442/jiter-0.15.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8c9004af7c8d67cce7f1aae1026fb55607f4aa600710d08ede3a3ce4aeefe7e0", size = 309570, upload-time = "2026-05-19T10:07:36.919Z" },
+    { url = "https://files.pythonhosted.org/packages/58/64/8fb7f9d45bb98190355454cd04dad8d8f27223d6bd52f83af07f637168a6/jiter-0.15.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c210f8b35dc6f30aafd4b4365ca89b9d1189f21ab49b8e68fa6322a847aef138", size = 336783, upload-time = "2026-05-19T10:07:38.694Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/b6/f5739011d009b3a30f6a53c5240979030ba29ae46a8c67e3a15759f7c37d/jiter-0.15.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5f30bae8bc1c2d613e28e5af3e8cceb09b742f1c8a8a5f839fb67afaffc03b61", size = 363555, upload-time = "2026-05-19T10:07:40.832Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/12/98a9d9f766665e8a3b6252454e17cb0c464606a28cf2fa09399b003345fa/jiter-0.15.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:c60e71b6d10cfc284c9bf36bd885e8d44c46f688ce50aa91b5edd90181dea687", size = 452255, upload-time = "2026-05-19T10:07:42.62Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/d5/60f972840f79c5e7544fce567c56f1e4e50468f996baba3e78d823dd62a6/jiter-0.15.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0ab068bce62a45aa3e7367eceaffb5dde60b7eb853be8dece45132e3d0ff4879", size = 373559, upload-time = "2026-05-19T10:07:44.201Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/cf/d46ef1234ba335aabc2f013210db8e0821a22f5e644a2e9449df199ecc23/jiter-0.15.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fa248c9eb220197d363f688818dac2fd4b2f0cd7d843ca7105d652034823427d", size = 346055, upload-time = "2026-05-19T10:07:46.005Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/63/4d2749d8d54d230bad9b3a6b0d00cc28c6ff6b2fdffc26a8ccf76cc5a974/jiter-0.15.0-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:2a77aadd57cac1682e4401a72724d2796d89a4ba129b1a5812aa94ee480826eb", size = 351406, upload-time = "2026-05-19T10:07:47.855Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/b9/9965b990035d8773328e0a8c8b457a87bf2b19f6c4126d9d99296be5d16a/jiter-0.15.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:2ae901f3a55bfafdde31d289590fa25e3245735a2b1e8c7cc15871710a002871", size = 389357, upload-time = "2026-05-19T10:07:49.665Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/55/9ddf903deda1413e87fed792f416b7123daee5b8efbad6a202a7421c36a5/jiter-0.15.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:f0b271b462769543716f92d3a4f90527df6ef5ed05ee95ec4137f513e21e1b77", size = 517263, upload-time = "2026-05-19T10:07:51.537Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/76/a0c40ad064d3a20a4fde231e35d56e9a01ce82164278180e82d5daf85469/jiter-0.15.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:2fb6a5d26af81fc0f00f9360a891e05cf755e149bba391c4d563adc54812973d", size = 548646, upload-time = "2026-05-19T10:07:53.196Z" },
+    { url = "https://files.pythonhosted.org/packages/23/4f/eca9b954942916ba2f453891b8593ab444cd872396fe66a3936616f236f3/jiter-0.15.0-cp312-cp312-win32.whl", hash = "sha256:c2f6bb8b5216ab9e7873bc08b5d7bef2b8abbb578a3069bf1cd14a45d71d771d", size = 206427, upload-time = "2026-05-19T10:07:55.307Z" },
+    { url = "https://files.pythonhosted.org/packages/95/bf/8ead82a87495149542748e828d153fd232a512a22c83b02c4815c1a9c7d8/jiter-0.15.0-cp312-cp312-win_amd64.whl", hash = "sha256:40b2c7e92c44a84d748d21706c68dc6ff8161d80b59c99d774721a0d2317d7c7", size = 197300, upload-time = "2026-05-19T10:07:56.651Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/e4/9b8a78fb2d894471bc344e37f1949bdd784bd914d031dba0ba3a40c71dd7/jiter-0.15.0-cp312-cp312-win_arm64.whl", hash = "sha256:cc0bc345cf2df9d1c00ac443f50d543c1ccfa8b0422cb85b1ab70d681c0b255b", size = 192702, upload-time = "2026-05-19T10:07:58.307Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/f4/f708c900ecee41b2025ef8413d5351e5649eb2125c506f6720cc69b06f5c/jiter-0.15.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:1c11465f97e2abf45a014b83b730222f8f1c5335e802c7055a67d50de6f1f4e3", size = 307829, upload-time = "2026-05-19T10:07:59.704Z" },
+    { url = "https://files.pythonhosted.org/packages/86/59/db537c0949e83668c38481d426b9f2fd5ab758c4ee53a811dd0a510626a0/jiter-0.15.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:d1e7b1776f0797956c509e123d0952d10d293a9492dea9f288ab9570ec01d1a5", size = 308445, upload-time = "2026-05-19T10:08:01.184Z" },
+    { url = "https://files.pythonhosted.org/packages/37/38/ea0e13b18c30ef951da0d47d39e7fa9edb82a93a62990ffbd7cea9b622d4/jiter-0.15.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:351a341c2105aa430b7047e30f1bf7975f6313b00165d3fc07be2edaf741f279", size = 336181, upload-time = "2026-05-19T10:08:02.688Z" },
+    { url = "https://files.pythonhosted.org/packages/58/fc/2303901b16c4ba05865588990a420c0b4156270b44379c20931544a1d962/jiter-0.15.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:4ab395feec8d249ec4044e228e98a7033f043426a265df439dc3698823f0a4e4", size = 362985, upload-time = "2026-05-19T10:08:04.394Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/6f/11bace093c52e7d4d26c8e606ccd7ae8c972189622469ec0d9e28161e28b/jiter-0.15.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a2a438005b6f22d0273413484d6094d7c2c5d10ec1b3a3bf128e0d1d3ba53258", size = 453292, upload-time = "2026-05-19T10:08:05.967Z" },
+    { url = "https://files.pythonhosted.org/packages/22/db/987f2f086ca4d7a6582eb4ccd513f9b26b42d9e4243a087609a3137a8fc7/jiter-0.15.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f18f85e4218d1b40f000f42a92239a7a61a902cd42c65e6c360dbd17dcb20894", size = 373501, upload-time = "2026-05-19T10:08:07.857Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/7c/89fbcabb2739b7a5b8dc959a1b6c5761f6484f5fed3486854b3c789bb1de/jiter-0.15.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d1aa62e277fc1cbd80e6deacae6f4d983b41b3d7728e0645c5d741a6149bba45", size = 344683, upload-time = "2026-05-19T10:08:09.431Z" },
+    { url = "https://files.pythonhosted.org/packages/30/6f/6cca7692e7dddfec6d8d76c54dc97f2af2a41df4ac0674b999df1f09a5f3/jiter-0.15.0-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:6550fa135c7deb8ead6af49ed7ff648532ea8334a1447fe34a36315ef79c5c29", size = 350892, upload-time = "2026-05-19T10:08:11.352Z" },
+    { url = "https://files.pythonhosted.org/packages/39/14/0338d6190cb8e6d22e677ab1d4eabd4117f67cca70c54cd04b82ff64e068/jiter-0.15.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:066f8f33f18b2419cd8213b2436fa7fbc9c499f315971cfa3ce1f9820c001b1b", size = 388723, upload-time = "2026-05-19T10:08:12.912Z" },
+    { url = "https://files.pythonhosted.org/packages/90/31/cc19f4a1bdb6afb09ce6a2f2615aa8d44d994eba0d8e6105ed1af920e736/jiter-0.15.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:75e8a04e91432dde9f1838373cf93d23726c79d3e908d319acf0e796f85592e7", size = 516648, upload-time = "2026-05-19T10:08:14.808Z" },
+    { url = "https://files.pythonhosted.org/packages/49/9f/833c541512cd091b63c10c0381973dfe11bc7a503a818c16384417e0c81e/jiter-0.15.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:a97261f1fccb8e50ecd2890a96e46efdc3f57c80a197324c6777827231eca712", size = 547382, upload-time = "2026-05-19T10:08:16.927Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/11/e7b70e91f90bc4477e8eee9e8a5f7cf3cb41b4525d6394dc98a714eb8f7f/jiter-0.15.0-cp313-cp313-win32.whl", hash = "sha256:c77496cb10bd7549690fbbab3e5ec05857b83e49276f4a9423a766ddd2afcd4c", size = 205845, upload-time = "2026-05-19T10:08:18.401Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/23/5c20d9ad6f02c493e4023e5d2d09e1c1f15fe2753c9102c544aff068a88e/jiter-0.15.0-cp313-cp313-win_amd64.whl", hash = "sha256:b15741f501469009ae0ae90b7147958a664a7dede40aa7ff174a8a4645f546d0", size = 196842, upload-time = "2026-05-19T10:08:20.131Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/11/1eb400ef248e8c925fd883fbe325daf5e42cd1b0d308539dd332bd4f7ffc/jiter-0.15.0-cp313-cp313-win_arm64.whl", hash = "sha256:5d6a60072b44c3c2b797a7ddcbcbbf2b34ea3cfd4721580fbfd2a09d9d9b84ba", size = 192212, upload-time = "2026-05-19T10:08:21.807Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/60/2fd8d7c79da8acf9b7b277c7616847773779356b92acfc9bb158452174da/jiter-0.15.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:ef1fd24d9413f6209e00d3d5a453e67acfe004a25cc6c8e8484faed4311ab9e8", size = 315065, upload-time = "2026-05-19T10:08:23.218Z" },
+    { url = "https://files.pythonhosted.org/packages/46/f4/008fb7d65e8ac2abf00811651a661e025c4ba80bbc6f378450384ddd3aed/jiter-0.15.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:144f8e72cb53dab146347b91cceac01f5481237f2b93b4a339a1ee8f8878b67c", size = 339444, upload-time = "2026-05-19T10:08:24.701Z" },
+    { url = "https://files.pythonhosted.org/packages/00/55/90b0c7b9c6896c0f2a591dd36d36b71d22e09674bfef178fa03ba3f81499/jiter-0.15.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:553fcac2ef2cb990877f9fc0833b8b629a3e6a5670b6b5fd58219b41a653ddc4", size = 347779, upload-time = "2026-05-19T10:08:26.408Z" },
+    { url = "https://files.pythonhosted.org/packages/51/6b/69666cec5000fd57734c118437394516c749ae8dbeea9fb66d6fef9c4775/jiter-0.15.0-cp313-cp313t-win_amd64.whl", hash = "sha256:774f93f65031856bf14ad9f59bdcab8b8cad501e5ceabd51ba3525f76937a25b", size = 200395, upload-time = "2026-05-19T10:08:28.055Z" },
+    { url = "https://files.pythonhosted.org/packages/39/04/a6aa62cd27e8149b0d28df5561f10f6cceaf7935a9ccf3f1c5a05f9a0cd8/jiter-0.15.0-cp313-cp313t-win_arm64.whl", hash = "sha256:f1e1754960f38ec40613a07e5e372df67acb3b890fb383b6fb3de3e49ddbf3c7", size = 190516, upload-time = "2026-05-19T10:08:29.35Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/d2/079f350ebf7859d081de30aa890f9e3be68516f754f3ba32366ffff4dcee/jiter-0.15.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:ac0d9ddea4350974be7a221fc25895f251a8fee748c889bdced2141c0fec1a49", size = 308884, upload-time = "2026-05-19T10:08:31.667Z" },
+    { url = "https://files.pythonhosted.org/packages/04/4e/a2c30a7f69b48c03b20935d647479106fe932f6e63f75faf53937197e05d/jiter-0.15.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:01a8222cf05ab1128e239421156c207949808acaaea2bdfd33130ae666786e86", size = 310028, upload-time = "2026-05-19T10:08:33.304Z" },
+    { url = "https://files.pythonhosted.org/packages/40/90/2e7cdfd3cf8ca967be38c48f5cf474d79f089efaf559a40f15984a77ae69/jiter-0.15.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:182226cbc930c9fab81bc2e41a4da672f89539906dadb05e75670ac07b94f71f", size = 337485, upload-time = "2026-05-19T10:08:35.259Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/11/15a1aa28b120b8ee5b4f1fb894c125046225f09847738bd64233d3b84883/jiter-0.15.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:71683c38c825452999b5717fcae07ea708e8c93003e808be4319c1b02e3d176e", size = 364223, upload-time = "2026-05-19T10:08:36.694Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/25/f442e8af5f3d0dcf47b39e83a0efd9ee45ea946aa6d04625dc3181eae3b6/jiter-0.15.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:30f2218e6a9e5c18bc10fe6d41ac189c442c88eacf11bad9f28ef95a9bef00e6", size = 456387, upload-time = "2026-05-19T10:08:38.143Z" },
+    { url = "https://files.pythonhosted.org/packages/da/f4/37f2d2c9f64f49af7da652ed7532bb5a2372e588e6927c3fdd76f911db65/jiter-0.15.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5157de9f76eb4bc5ea74a1219366a25f945ad305641d74e04f59c54087091aa9", size = 374461, upload-time = "2026-05-19T10:08:39.869Z" },
+    { url = "https://files.pythonhosted.org/packages/60/28/edcfbbbf0cb15436f36664a8908a0df47ab9006298d4cd937dc08ea932d6/jiter-0.15.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:90c5db5527c221249a876160663ab891ace358c17f7b9c93ec1478b7f0550e5c", size = 345924, upload-time = "2026-05-19T10:08:41.668Z" },
+    { url = "https://files.pythonhosted.org/packages/47/13/89fba6398dab7f202b7278c4b4aac122399d2c0183971c4a57a3b7088df5/jiter-0.15.0-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:3e4540b8e74e4268811ac05db226a6a128ff572e7e0ce3f1163b693cadb184cd", size = 352283, upload-time = "2026-05-19T10:08:43.091Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/da/0f6af8cef2c565a1ab44d970f268c43ccaa72707386ea6388e6fe2b6cd26/jiter-0.15.0-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:62ebd14e47e9aed9df4472afcb2663668ce4d74891cd54f86bf6e44029d6dc89", size = 389985, upload-time = "2026-05-19T10:08:44.915Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/ec/b9cb7d6d29e24ee14910266157d2a279d7a8f60ee0df7fa840882976ba64/jiter-0.15.0-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:0be6f5ad41a809f303f416d17cec92a7a725902fb9b4f3de3d19362ac0ef8554", size = 517695, upload-time = "2026-05-19T10:08:46.486Z" },
+    { url = "https://files.pythonhosted.org/packages/64/5e/6d1bda880723aae0ad86b4b763f044362448efe31e3e819635d41cb03451/jiter-0.15.0-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:813dfbb17d65328bf86e5f0905dd277ba2265d3ca20556e86c0c7035b7182e5a", size = 548868, upload-time = "2026-05-19T10:08:48.026Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/72/7de501cf38dcacaf35098796f3a50e0f2e338baba18a58946c618544b809/jiter-0.15.0-cp314-cp314-win32.whl", hash = "sha256:50e51156192722a9c58db112837d3f8ef96fb3c5ecc14e95f409134b08b158ec", size = 206380, upload-time = "2026-05-19T10:08:49.738Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/a9/e19addf4b0c1bdce52c6da12351e6bc42c340c45e7c09e2158e46d293ccc/jiter-0.15.0-cp314-cp314-win_amd64.whl", hash = "sha256:30ce1a5d16b5641dc935d50ef775af6a0871e3d14ab05d6fc54dff371b78e558", size = 197687, upload-time = "2026-05-19T10:08:51.088Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/c9/776b1db01db25fc6c1d58d1979a37b0a9fe787e5f5b1d062d2eaacb77923/jiter-0.15.0-cp314-cp314-win_arm64.whl", hash = "sha256:510c8b3c17a0ed9ac69850c0438dada3c9b82d9c4d589fcb62002a5a9cf3a866", size = 192571, upload-time = "2026-05-19T10:08:52.451Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/f6/45bb4670bacf300fd2c7abadbfb3af376e5f1b6ae75fd9bc069891d15870/jiter-0.15.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7553333dd0930c104a5a0db8df72bf7219fe663d731383b576bb6ed6351c984d", size = 317151, upload-time = "2026-05-19T10:08:53.867Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/68/ed635ad5acd7b73e454283083bbb7c8205ad10e88b0d9d7d793b09fe8226/jiter-0.15.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f2143ab06181d2b029eedcb6af3cebe95f11bbac62441781860f98ee9330a6a6", size = 341243, upload-time = "2026-05-19T10:08:55.383Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/db/3ff4176b817b8ea33879e71e13d8bc2b0d481a7ed3fe9e080f333d415c16/jiter-0.15.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:6eac374c5c975709b69c10f09afd199df74150172156ad10c8d4fd785b7da995", size = 363629, upload-time = "2026-05-19T10:08:56.928Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/24/5f8270e0ba9c883582f96f722f8a0b58015c7ce1f8c6d4571cf394e99b6b/jiter-0.15.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b3b3b775e33d3bfaec9899edc526ae97b0da0bf9d071a46124ba419149a414f8", size = 456198, upload-time = "2026-05-19T10:08:58.618Z" },
+    { url = "https://files.pythonhosted.org/packages/45/5b/76fc02b0b5c54c3d18c60653156e2f76fde1816f9b4722db68d6ee2c897e/jiter-0.15.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:eda3071db3346334beae1360b46da4606da57bf3528c167b3c38533afaf9f2c5", size = 373710, upload-time = "2026-05-19T10:09:00.151Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/52/4310821b0ea9277994d3e1f49fc6a4b34e4800caebacb2c0af81da59a454/jiter-0.15.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c6694a173ecabc12eb60efbc0b474464ead1951ff65cd8b1e72100715c64512b", size = 349901, upload-time = "2026-05-19T10:09:01.621Z" },
+    { url = "https://files.pythonhosted.org/packages/93/fe/67648c35b3594fba8854ac64cc8a826d8bcd18324bbdb53d77697c60b6ef/jiter-0.15.0-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:a254e10b593624d230c365b6d616b22ca0ad65e63a16e6631c2b3466022e6ba8", size = 352438, upload-time = "2026-05-19T10:09:03.216Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/28/0a1879d07ad6b3e025a2750027363452ced93c2d16d1c9d4b153ffd51c91/jiter-0.15.0-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d8d2955167274e15d79a7a020afdd9b39c990eb80b2d89fca695d92dcfdd38ec", size = 388152, upload-time = "2026-05-19T10:09:04.741Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/78/46c6f6b56ba85c90021f4afd72ed42f691f8f84daacb5fe27277070e3858/jiter-0.15.0-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:acf4ee4d1fc55917239fe72972fb292dd773055d05eb040d36f4326e02cc2c0e", size = 517707, upload-time = "2026-05-19T10:09:06.231Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/cb/720662d4c88fcad606e826fef5424365527ba43ce4868a479aed8f8c507e/jiter-0.15.0-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:e7196e56f1cd69af1dbb07dff02dcfb260a50b45a82d409d92a06fedb32473b5", size = 548241, upload-time = "2026-05-19T10:09:08.093Z" },
+    { url = "https://files.pythonhosted.org/packages/60/e3/935b8034fd143f21125c87d51404a9e0e1449186a494405721ff5d1d695e/jiter-0.15.0-cp314-cp314t-win32.whl", hash = "sha256:7f6163c0f10b055245f814dcc59f4818da60dfe72f3e72ab89fc24b6bd5e9c52", size = 207950, upload-time = "2026-05-19T10:09:09.616Z" },
+    { url = "https://files.pythonhosted.org/packages/93/59/984fd9ece895953dad3e0880a650e766f5a2da2c5514f0eafdaaabbeb5f9/jiter-0.15.0-cp314-cp314t-win_amd64.whl", hash = "sha256:980c256edb05b78a111b99c4de3b1d32e31634b867fd1fc2cf726e7b7bba9854", size = 200055, upload-time = "2026-05-19T10:09:11.367Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/a4/cf8d779feb133a27a2e3bc833bccb9e13aa332cdf820497ebf72c10ce8c3/jiter-0.15.0-cp314-cp314t-win_arm64.whl", hash = "sha256:66b1880df2d01e206e8339769d1c7c1753bcb653efd6289e203f6f24ebada0c0", size = 191244, upload-time = "2026-05-19T10:09:12.74Z" },
+    { url = "https://files.pythonhosted.org/packages/73/38/505941b2b092fd5bbbd60a52a880db1173f1690ae6751bed3af1c9ddcb4e/jiter-0.15.0-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:631f13a3d04e97d4e083993b10f4b99530e3a10d953e2eb5e196b7dc7f812ce0", size = 303769, upload-time = "2026-05-19T10:09:42.203Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/95/a06692b29e77473f286e1ec1f426d3ca44d7b5843be8ad21d7a5f3fcdcc0/jiter-0.15.0-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:b6c0ffae686c39bf3737be60793783267628783ea42545632c10b291105aee45", size = 305128, upload-time = "2026-05-19T10:09:43.657Z" },
+    { url = "https://files.pythonhosted.org/packages/23/85/7270d7ad41d6061a25b950c6bf91d638bd9aacb113200a8c8d57a055fd67/jiter-0.15.0-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1d54fb5b31dea401a41af3f8a7d2512e9b6a6a005491e6166c7e4ffab9639a9c", size = 340459, upload-time = "2026-05-19T10:09:45.452Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/8d/302cb2057b7513327b4d575cff6b1d066ee6431a5357fc3f8867cd684406/jiter-0.15.0-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:54d5d6090cdc1b7c9e780dfb04949a990adb1e301a2fc0bbcee7de4638d33f9a", size = 344469, upload-time = "2026-05-19T10:09:46.864Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Ports the generic LLM **agent framework** from `clarity-auto-care` into `baski.agents` so other projects (e.g. `nisse`) can reuse it. Built on Anthropic's Claude API.

### What's included
- **`Agent` / `AgentConfig`** — agentic loop: streaming responses, parallel tool execution, conversation management. Auto-injects `KnowledgeTool` and `DeleteMessagesTool`.
- **`ToolBox` / `Tool`** — tool registry + parallel (`asyncio.gather`) executor; abstract `Tool` base.
- **`MessageHistory`** — turn-based history with context-window truncation (64k default, truncate at 90%).
- **`TraceCollector`** — turn-by-turn traces to GCS (gzipped JSON) + a Mongo `traces` summary collection.
- **`pricing` / `ExecutionStats`** — token accounting and USD cost.
- **Built-in tools** — Google / Yelp / Google Play / Apple App Store search (SerpApi), web browse (Playwright), knowledge store, delete-messages.

Adds `anthropic` to dependencies (+ `uv.lock`).

### Conventions applied on import
The port originally used clarity's looser style; brought in line with baski's strict config:
- **camelCase → snake_case** on all model fields, the `AgentExecuteResult` contract, and the GCS/Mongo trace schema (no existing baski consumer yet).
- SerpApi response dicts typed per the repo convention (`dict` + `# noqa: ANON002`).
- `Tool` class attrs made `ClassVar`; `_turn` properties replace `_current_turn` None-access (fail-fast `RuntimeError`, no `assert`).

### Not ported
The clarity FastAPI trace-browser router is deployment-specific — add a thin router in the consuming project if a trace UI is needed.

### Verification
- `make lint` (ruff + anon_lint) — passes
- `make typecheck` (mypy, strict) — passes
- pre-push hook — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
