### PR TITLE
Fix agent trace serialization under pydantic 2.13 (ValidatorIterator)

### DIFF
--- a/baski/agents/trace.py
+++ b/baski/agents/trace.py
@@ -8,7 +8,7 @@ from typing import NamedTuple, cast
 from anthropic.types import Message, MessageParam, TextBlock, ThinkingBlock, ToolResultBlockParam, ToolUseBlock
 from google.api_core.exceptions import GoogleAPIError
 from google.cloud import storage
-from pydantic import BaseModel, ConfigDict, field_serializer
+from pydantic import BaseModel, ConfigDict, SkipValidation, field_serializer
 from pymongo.asynchronous.database import AsyncDatabase
 
 from baski.concurrent import as_async
@@ -61,7 +61,9 @@ class TurnRecord(BaseModel):
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
     turn_number: int
-    messages: list[MessageParam]
+    # Already-valid anthropic params, kept only to serialize. SkipValidation stops pydantic
+    # from re-validating and turning each `content` list into a single-use ValidatorIterator.
+    messages: SkipValidation[list[MessageParam]]
     thinking: list[str] = []
     text_response: str | None = None
     tool_calls: list[ToolUseBlock] = []


### PR DESCRIPTION
## What changed

`TurnRecord.messages` is now `SkipValidation[list[MessageParam]]`, and `serialize_messages` reverts to the trivial list handling.

## Why

anthropic types `MessageParam.content` as `Union[str, Iterable[<block>]]`. Pydantic v2 (2.13.4) validates an `Iterable[...]` annotation **lazily** — it replaces the input list with a single-use `ValidatorIterator`. So when `TurnRecord` validated `list[MessageParam]`, every `content` list became an iterator; `serialize_messages` only handled `list` and wrapped the iterator as `[iterator]`, so `SerializedMessage` validation failed and **every `Agent.execute()` crashed in `trace.finalize()`**.

These messages are already-valid anthropic params kept only to serialize for the trace — there's no reason to re-validate them. `SkipValidation` keeps `content` a real list (no `ValidatorIterator`), makes the record safely re-dumpable, and lets the serializer stay trivial. Fixes the cause, not the symptom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
