### PR TITLE
Add agent step-event listeners + non-blocking trace finalize

### DIFF
--- a/baski/agents/__init__.py
+++ b/baski/agents/__init__.py
@@ -1,9 +1,36 @@
 """Agent framework for LLM-powered tool-use conversations."""
 
 from .agent import Agent, AgentConfig
+from .events import (
+    AgentEvent,
+    Completed,
+    EventType,
+    Listener,
+    Thinking,
+    ToolFinished,
+    ToolStarted,
+    TurnStarted,
+    noop,
+)
 from .execute_result import AgentExecuteResult
 from .message_history import MessageHistory
 from .tool import Tool
 from .toolbox import ToolBox
 
-__all__ = ["Agent", "AgentConfig", "AgentExecuteResult", "MessageHistory", "Tool", "ToolBox"]
+__all__ = [
+    "Agent",
+    "AgentConfig",
+    "AgentEvent",
+    "AgentExecuteResult",
+    "Completed",
+    "EventType",
+    "Listener",
+    "MessageHistory",
+    "Thinking",
+    "Tool",
+    "ToolBox",
+    "ToolFinished",
+    "ToolStarted",
+    "TurnStarted",
+    "noop",
+]

--- a/baski/agents/agent.py
+++ b/baski/agents/agent.py
@@ -12,6 +12,7 @@ from pymongo.asynchronous.database import AsyncDatabase
 from baski.primitives import datetime
 from baski.server import Logger
 
+from .events import Completed, Listener, Thinking, ToolFinished, ToolStarted, TurnStarted, noop
 from .execute_result import AgentExecuteResult
 from .message_history import MessageHistory
 from .pricing import ExecutionStats
@@ -156,16 +157,30 @@ class Agent:
         ]
 
     async def _execute_tools(
-        self, tool_calls: list[ToolUseBlock], stats: ExecutionStats, trace: TraceCollector
+        self, tool_calls: list[ToolUseBlock], stats: ExecutionStats, trace: TraceCollector, on_event: Listener
     ) -> None:
         """Execute tool calls and record results in history and trace."""
         stats.tool_calls += len(tool_calls)
         self.logger.info(
             "Tools execution", labels={"toolCount": len(tool_calls), "tools": [tc.name for tc in tool_calls]}
         )
+        for tc in tool_calls:
+            await on_event(ToolStarted(name=tc.name, tool_input=dict(tc.input) if isinstance(tc.input, dict) else {}))
+
         tool_results = await self.toolbox.execute(tool_calls)
         self.message_history.add_tool_results(tool_results)
         trace.record_tool_results(tool_results, self.toolbox.last_timings)
+
+        name_by_id = {tc.id: tc.name for tc in tool_calls}
+        for result in tool_results:
+            tool_id = result["tool_use_id"]
+            await on_event(
+                ToolFinished(
+                    name=name_by_id.get(tool_id, ""),
+                    ok=not result.get("is_error", False),
+                    duration_ms=self.toolbox.last_timings.get(tool_id, 0),
+                )
+            )
 
     def _collect_text(self, text_blocks: list[TextBlock]) -> str | None:
         """Join text blocks into a single user-facing message string."""
@@ -176,7 +191,7 @@ class Agent:
         return message_to_user
 
     async def _run_turn(
-        self, user_request_message: MessageParam, stats: ExecutionStats, trace: TraceCollector
+        self, user_request_message: MessageParam, stats: ExecutionStats, trace: TraceCollector, on_event: Listener
     ) -> TurnResult:
         """Run a single agentic turn: build messages, call API, parse response, execute tools."""
         messages = self._build_messages(user_request_message)
@@ -187,6 +202,7 @@ class Agent:
         api_duration_ms = int((time.monotonic() - start) * 1000)
 
         stats.collect(message.usage)
+        await on_event(TurnStarted(turn=stats.turn_count))
         if len(self.message_history) == 0 and message.usage.input_tokens > self.message_history.max_tokens // 2:
             raise RuntimeError("Initial context is too large. Try to provide more LLM context.")
 
@@ -194,10 +210,14 @@ class Agent:
         parsed = self._parse_response(message.content)
         trace.record_response(message, api_duration_ms)
 
+        for block in message.content:
+            if isinstance(block, ThinkingBlock):
+                await on_event(Thinking(text=block.thinking))
+
         with self.message_history:
             self.message_history.add_assistant(message.content)
             if parsed.tool_calls:
-                await self._execute_tools(parsed.tool_calls, stats, trace)
+                await self._execute_tools(parsed.tool_calls, stats, trace, on_event)
 
         trace.end_turn()
         return TurnResult(
@@ -205,11 +225,15 @@ class Agent:
             has_tool_calls=bool(parsed.tool_calls),
         )
 
-    async def execute(self, user_request: str) -> AgentExecuteResult:
+    async def execute(self, user_request: str, on_event: Listener = noop) -> AgentExecuteResult:
         """Execute user request.
 
         It can be called multiple times however the context is preserved. Each following
         call will have context from previous calls.
+
+        `on_event` is an optional async listener that receives step events (turn start,
+        thinking, tool start/finish, completion) as the loop runs — the seam for live
+        progress UIs. The agent stays transport-agnostic; the listener owns rendering.
         """
         user_request_message = MessageParam(
             role="user", content=[TextBlockParam(type="text", text=f"YOUR TASK IS: {user_request}")]
@@ -231,12 +255,14 @@ class Agent:
         turn = TurnResult(message_to_user=None, has_tool_calls=False)
         try:
             while True:
-                turn = await self._run_turn(user_request_message, stats, trace)
+                turn = await self._run_turn(user_request_message, stats, trace, on_event)
                 if not turn.has_tool_calls:
                     break
         except Exception as e:
-            await trace.finalize(stats, error=str(e))
+            trace.finalize(stats, error=str(e))
             raise
+
+        await on_event(Completed(response=turn.message_to_user))
 
         self.logger.info(
             "Agent execution complete",
@@ -253,6 +279,6 @@ class Agent:
             total_cost=stats.cost,
         )
 
-        await trace.finalize(stats, result)
+        trace.finalize(stats, result)
 
         return result

--- a/baski/agents/events.py
+++ b/baski/agents/events.py
@@ -1,0 +1,70 @@
+"""Transport-agnostic agent step events.
+
+The agent loop emits these as it runs; a listener (callback) renders them. The
+agent knows nothing about who is listening — Telegram, a CLI, a test, a trace.
+Keep this module free of any transport concept (no chat id, no aiogram, no HTTP).
+"""
+
+from collections.abc import Awaitable, Callable
+from enum import StrEnum
+
+from pydantic import BaseModel
+
+
+class EventType(StrEnum):
+    """Tag for the agent step events."""
+
+    TURN_STARTED = "turn_started"
+    THINKING = "thinking"
+    TOOL_STARTED = "tool_started"
+    TOOL_FINISHED = "tool_finished"
+    COMPLETED = "completed"
+
+
+class TurnStarted(BaseModel):
+    """A new agentic turn has begun (one model call + its tool calls)."""
+
+    type: EventType = EventType.TURN_STARTED
+    turn: int
+
+
+class Thinking(BaseModel):
+    """The model produced extended-thinking text this turn (may be long)."""
+
+    type: EventType = EventType.THINKING
+    text: str
+
+
+class ToolStarted(BaseModel):
+    """A tool is about to execute."""
+
+    type: EventType = EventType.TOOL_STARTED
+    name: str
+    tool_input: dict[str, object]
+
+
+class ToolFinished(BaseModel):
+    """A tool finished executing."""
+
+    type: EventType = EventType.TOOL_FINISHED
+    name: str
+    ok: bool
+    duration_ms: int
+
+
+class Completed(BaseModel):
+    """The agent finished and produced its final answer (or None)."""
+
+    type: EventType = EventType.COMPLETED
+    response: str | None
+
+
+AgentEvent = TurnStarted | Thinking | ToolStarted | ToolFinished | Completed
+
+# A listener is any async callable that consumes one event. Compose several by
+# wrapping them in one function; the agent takes a single listener for simplicity.
+Listener = Callable[[AgentEvent], Awaitable[None]]
+
+
+async def noop(_event: AgentEvent) -> None:
+    """Default listener — drops every event."""

--- a/baski/agents/trace.py
+++ b/baski/agents/trace.py
@@ -1,17 +1,20 @@
 """Agent trace collection and persistence to GCS and MongoDB."""
 
+import asyncio
 import gzip
 import time
 import uuid
 from typing import NamedTuple, cast
 
+import anyio
 from anthropic.types import Message, MessageParam, TextBlock, ThinkingBlock, ToolResultBlockParam, ToolUseBlock
 from google.api_core.exceptions import GoogleAPIError
 from google.cloud import storage
 from pydantic import BaseModel, ConfigDict, SkipValidation, field_serializer
 from pymongo.asynchronous.database import AsyncDatabase
+from pymongo.errors import PyMongoError
 
-from baski.concurrent import as_async
+from baski.concurrent import as_async, as_task
 from baski.primitives import datetime, json
 from baski.server import Logger
 
@@ -19,6 +22,16 @@ from .execute_result import AgentExecuteResult
 from .pricing import ExecutionStats
 
 TRACES_PREFIX = "traces/"
+
+# Strong references to detached trace-persistence tasks: asyncio keeps only a weak ref to a
+# bare task, so without this a fire-and-forget task can be garbage-collected mid-flight.
+_pending: set[asyncio.Task] = set()
+
+
+def _track(task: asyncio.Task) -> None:
+    """Hold a strong ref to a detached task until it finishes, then drop it."""
+    _pending.add(task)
+    task.add_done_callback(_pending.discard)
 
 
 class TraceCollectorConfig(NamedTuple):
@@ -193,16 +206,25 @@ class TraceCollector:
         self._turns.append(turn)
         self._current_turn = None
 
-    async def finalize(
+    def finalize(
         self, stats: ExecutionStats, result: AgentExecuteResult | None = None, error: str | None = None
     ) -> None:
-        """Persist trace to GCS and MongoDB."""
+        """Schedule trace persistence (GCS + MongoDB) as a detached background task.
+
+        Fire-and-forget: the agent's reply path never blocks on — or fails from — trace IO.
+        Traces are debug-only; losing one (e.g. if Cloud Run throttles the instance after the
+        response is sent) is acceptable, a broken reply is not.
+        """
         if result is not None:
             self._result = result
         self._error = error
+        _track(as_task(self._persist(stats)))
 
-        await self._upload_to_gcs()
-        await self._save_to_db(stats)
+    async def _persist(self, stats: ExecutionStats) -> None:
+        """Upload to GCS and save to MongoDB concurrently; each isolates its own failure."""
+        async with anyio.create_task_group() as tg:
+            tg.start_soon(self._upload_to_gcs)
+            tg.start_soon(self._save_to_db, stats)
 
     async def _upload_to_gcs(self) -> None:
         upload_error: str | None = None
@@ -251,5 +273,9 @@ class TraceCollector:
             "cost": stats.cost,
             "error": self._error,
         }
-        await self._database["traces"].insert_one(doc)
+        try:
+            await self._database["traces"].insert_one(doc)
+        except PyMongoError:
+            self._logger.exception("Failed to save trace to DB", labels={"traceId": self.id})
+            return
         self._logger.info("Trace saved to DB", labels={"traceId": self.id})

--- a/baski/primitives/json.py
+++ b/baski/primitives/json.py
@@ -30,7 +30,7 @@ def loadf(file_path: str | Path) -> Any:  # noqa: ANN401 — JSON deserializer r
 
 def dump(data: Any, fp: IO[str]) -> None:  # noqa: ANN401 — JSON serializer accepts any JSON-compatible value
     """Encode data as JSON to a file-like object with datetime support."""
-    return true_json.dump(data, fp, default=convert_date, indent=2, sort_keys=True)
+    return true_json.dump(data, fp, default=convert_date, indent=2, sort_keys=True, ensure_ascii=False)
 
 
 def dumps(
@@ -40,7 +40,7 @@ def dumps(
     sort_keys: bool = True,
 ) -> str:
     """Encode data as a JSON string with datetime support."""
-    return true_json.dumps(data, default=convert_date, indent=indent, sort_keys=sort_keys)
+    return true_json.dumps(data, default=convert_date, indent=indent, sort_keys=sort_keys, ensure_ascii=False)
 
 
 def dumpf(data: Any, file_path: str | Path) -> None:  # noqa: ANN401 — JSON serializer accepts any JSON-compatible value

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ authors = [{ name = "Vladimir Baskakov" }]
 
 dependencies = [
     "anthropic",
+    "anyio",
     "pyyaml",
     "python-dateutil",
     "pytz",

--- a/uv.lock
+++ b/uv.lock
@@ -247,6 +247,7 @@ source = { editable = "." }
 dependencies = [
     { name = "aiogram" },
     { name = "anthropic" },
+    { name = "anyio" },
     { name = "beautifulsoup4" },
     { name = "cryptography" },
     { name = "fastapi" },
@@ -289,6 +290,7 @@ dev = [
 requires-dist = [
     { name = "aiogram", specifier = ">=3" },
     { name = "anthropic" },
+    { name = "anyio" },
     { name = "beautifulsoup4" },
     { name = "cryptography" },
     { name = "fastapi" },


### PR DESCRIPTION
## What

Three changes to `baski.agents` / primitives, useful together for building live agent UIs:

### 1. Agent step-event listeners (main change)
`Agent.execute(user_request, on_event=...)` now accepts an optional async listener and emits **transport-agnostic** step events as the loop runs:

- `TurnStarted` · `Thinking` · `ToolStarted` · `ToolFinished` · `Completed`

Events live in `baski/agents/events.py` as a small Pydantic union tagged by an `EventType` (`StrEnum`). The listener (`Listener = Callable[[AgentEvent], Awaitable[None]]`, default `noop`) is **threaded down the call stack** — no instance state — so the agent stays unaware of Telegram/HTTP/any transport, and the consumer (a progress UI, a trace, a test) owns rendering.

```python
async def on_event(ev: AgentEvent) -> None:
    match ev:
        case ToolStarted(name=n): ...

await Agent(config=cfg).execute("book a table", on_event=on_event)
```

### 2. Non-blocking trace finalize
`TraceCollector.finalize` is now fire-and-forget: persistence runs in a tracked background task (kept alive against GC), and GCS upload + Mongo save run concurrently via an `anyio` task group. `execute()` no longer blocks on trace I/O at the end of a run. Adds the `anyio` dependency.

### 3. UTF-8 in JSON output
`json.dumps`/`dump` now pass `ensure_ascii=False`. Logs and trace files no longer escape Cyrillic/non-ASCII to `\uXXXX` — e.g. `"Найди новости"` instead of `"Найди ..."`.

## Test plan
- `make ci` green (ruff format + ruff + anon_lint + mypy + pytest, 40 tests).
- Step events verified by wiring a Telegram progress listener in a downstream app (nisse).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
