### PR TITLE
Make tool execution failures non-fatal

### DIFF
--- a/baski/agents/toolbox.py
+++ b/baski/agents/toolbox.py
@@ -59,13 +59,29 @@ class ToolBox:
             self.logger.error("Tool not found", labels={"toolName": tool_name})
             self.last_timings[tool_call.id] = 0
             return ToolResultBlockParam(
-                type="tool_result", tool_use_id=tool_call.id, content=f"Error: Tool {tool_name} not found"
+                type="tool_result",
+                tool_use_id=tool_call.id,
+                content=f"Error: Tool {tool_name} not found",
+                is_error=True,
             )
 
         tool = self._tools[tool_name]
         start = time.monotonic()
 
-        result = await tool.execute(**tool_input)
+        try:
+            result = await tool.execute(**tool_input)
+        except Exception as exc:
+            # A tool raising must not kill the whole agent run. Hand the error back to
+            # the model as a failed tool_result so it can recover or report it.
+            self.logger.exception("Tool execution failed", labels={"toolName": tool_name, "error": str(exc)})
+            self.last_timings[tool_call.id] = int((time.monotonic() - start) * 1000)
+            return ToolResultBlockParam(
+                type="tool_result",
+                tool_use_id=tool_call.id,
+                content=f"Error executing tool {tool_name}: {exc}",
+                is_error=True,
+            )
+
         self.last_timings[tool_call.id] = int((time.monotonic() - start) * 1000)
         return ToolResultBlockParam(type="tool_result", tool_use_id=tool_call.id, content=result)
 


### PR DESCRIPTION
## Problem

A tool that raises crashed the whole agent run. The exception propagated unguarded:

`ToolBox._execute_single` → `asyncio.gather` → `Agent.execute` → the Telegram webhook handler → **HTTP 500**. Telegram then redelivered the same update → the run crashed again → **crash loop**.

Observed in prod (`browse_website` raising `RuntimeError: PlaywrightClient not initialized` on every call).

## Fix

In `ToolBox._execute_single`, catch the exception, log it with a full stack trace (`logger.exception`), and hand the failure back to the model as an `is_error` tool_result:

```python
try:
    result = await tool.execute(**tool_input)
except Exception as exc:
    self.logger.exception("Tool execution failed", labels={"toolName": tool_name, "error": str(exc)})
    self.last_timings[tool_call.id] = int((time.monotonic() - start) * 1000)
    return ToolResultBlockParam(
        type="tool_result", tool_use_id=tool_call.id,
        content=f"Error executing tool {tool_name}: {exc}", is_error=True,
    )
```

The agent awaits a `tool_result` for every `tool_use`, so returning a result (rather than raising) is what unblocks the loop — and the model now sees *what failed* and can recover or report it instead of the webhook 500'ing.

Also wraps the existing "Tool not found" branch with `is_error=True` for consistency (the formatter re-flowed that line).

## Verification

- Lint clean (`ruff`), compiles.
- A raising tool now returns from `ToolBox.execute()` instead of propagating, with `is_error=True` and `content="Error executing tool boom: ..."`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
