### PR TITLE
Emit dispatcher startup/shutdown in webhook mode

### DIFF
--- a/baski/telegram/server.py
+++ b/baski/telegram/server.py
@@ -97,7 +97,11 @@ class TelegramServer(AsyncServer):
             info = await self.bot.get_webhook_info()
             if info.url != webhook_url:
                 await retry(self.bot.set_webhook, exceptions=(TelegramAPIError,), url=webhook_url)
+            # feed_webhook_update never fires the dispatcher startup/shutdown events that
+            # start_polling emits, so router on_startup hooks (client init) must be driven here.
+            await self.dp.emit_startup(bot=self.bot)
             yield
+            await self.dp.emit_shutdown(bot=self.bot)
             await self.bot.session.close()
 
         app = FastAPI(lifespan=lifespan, openapi_url=None)


### PR DESCRIPTION
## Problem

`browse_website` failed with `RuntimeError: PlaywrightClient not initialized` on **every** call in cloud, but worked locally.

Root cause: the two run modes start up differently.

- **Polling** (`_run_polling`): `dp.start_polling()` internally emits the dispatcher `startup`/`shutdown` events → router `on_startup` hooks run → Playwright + httpx async contexts are entered.
- **Webhook** (`_run_webhook`, cloud): updates are dispatched via `dp.feed_webhook_update`, which does **not** emit those events. The FastAPI `lifespan` only registered the webhook, so `on_startup` never ran and the async clients stayed uninitialized.

That's why it only broke in prod.

## Fix

Drive the dispatcher lifecycle explicitly in the webhook lifespan, mirroring what polling does:

```python
await self.dp.emit_startup(bot=self.bot)
yield
await self.dp.emit_shutdown(bot=self.bot)
await self.bot.session.close()
```

## Verification

- `emit_startup` / `emit_shutdown` confirmed present on `aiogram.Dispatcher`.
- Lint clean (`ruff`), compiles.
- Full runtime confirmation requires a cloud deploy (webhook mode isn't exercised locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
