### PR TITLE
feat: non-blocking Telegram webhook via Cloud Tasks; agent refusal + knowledge fixes

### DIFF
--- a/baski/agents/__init__.py
+++ b/baski/agents/__init__.py
@@ -1,11 +1,12 @@
 """Agent framework for LLM-powered tool-use conversations."""
 
-from .agent import Agent, AgentConfig
+from .agent import Agent, AgentConfig, AgentRefusalError
 from .events import (
     AgentEvent,
     Completed,
     EventType,
     Listener,
+    Message,
     Thinking,
     ToolFinished,
     ToolStarted,
@@ -22,9 +23,11 @@ __all__ = [
     "AgentConfig",
     "AgentEvent",
     "AgentExecuteResult",
+    "AgentRefusalError",
     "Completed",
     "EventType",
     "Listener",
+    "Message",
     "MessageHistory",
     "Thinking",
     "Tool",

--- a/baski/agents/agent.py
+++ b/baski/agents/agent.py
@@ -13,6 +13,7 @@ from baski.primitives import datetime
 from baski.server import Logger
 
 from .events import Completed, Listener, Thinking, ToolFinished, ToolStarted, TurnStarted, noop
+from .events import Message as MessageEvent
 from .execute_result import AgentExecuteResult
 from .message_history import MessageHistory
 from .pricing import ExecutionStats
@@ -22,6 +23,14 @@ from .tools import DeleteMessagesTool, KnowledgeTool
 from .trace import TraceCollector, TraceCollectorConfig
 
 DEFAULT_MODEL = "claude-opus-4-8"
+
+
+class AgentRefusalError(RuntimeError):
+    """The model returned stop_reason='refusal'.
+
+    Anthropic's safety classifier halted generation with no usable output. Raised
+    immediately so the caller can surface it instead of silently falling back.
+    """
 
 
 class ParsedResponse(NamedTuple):
@@ -95,7 +104,11 @@ class Agent:
         } | params
 
     async def _call_api(self, messages: list[MessageParam]) -> Message:
-        """Streaming API call with retry on api_error (max 1 retry, 2s sleep)."""
+        """Streaming API call with retry on api_error (max 1 retry, 2s sleep).
+
+        Raises AgentRefusalError on a `refusal` stop_reason — caught here, before the
+        message reaches history, so the refused content never gets fed back in.
+        """
         max_retries = 1
         retry_count = 0
 
@@ -105,23 +118,23 @@ class Agent:
                     messages=messages,
                     **self.params,  # type: ignore[arg-type]  # params is a dynamic dict merged with caller overrides
                 ) as stream:
-                    return await stream.get_final_message()
+                    message = await stream.get_final_message()
             except APIStatusError as e:
                 if retry_count < max_retries and "api_error" in str(e):
                     retry_count += 1
                     self.logger.warning(
                         "Anthropic API error, retrying",
-                        labels={
-                            "retryCount": retry_count,
-                            "maxRetries": max_retries,
-                            "error": str(e),
-                        },
+                        labels={"retryCount": retry_count, "maxRetries": max_retries, "error": str(e)},
                     )
                     await asyncio.sleep(2)
                     continue
                 raise
             except AnthropicAPIError:
                 raise
+
+            if message.stop_reason == "refusal":
+                raise AgentRefusalError("Model returned stop_reason='refusal'")
+            return message
 
         raise RuntimeError("Unreachable: retry loop exited without return or raise")
 
@@ -190,6 +203,20 @@ class Agent:
         self.logger.info("Text received", labels={"message_to_user": message_to_user})
         return message_to_user
 
+    async def _emit_step_events(self, message: Message, parsed: ParsedResponse, on_event: Listener) -> str | None:
+        """Surface this turn's thinking and pre-tool narration to the listener; return the text.
+
+        Narration before tool calls is user-facing; the final turn's text (no tool calls) is
+        the answer and is delivered via Completed, not here.
+        """
+        for block in message.content:
+            if isinstance(block, ThinkingBlock):
+                await on_event(Thinking(text=block.thinking))
+        text = self._collect_text(parsed.text_blocks)
+        if text and parsed.tool_calls:
+            await on_event(MessageEvent(text=text))
+        return text
+
     async def _run_turn(
         self, user_request_message: MessageParam, stats: ExecutionStats, trace: TraceCollector, on_event: Listener
     ) -> TurnResult:
@@ -210,9 +237,7 @@ class Agent:
         parsed = self._parse_response(message.content)
         trace.record_response(message, api_duration_ms)
 
-        for block in message.content:
-            if isinstance(block, ThinkingBlock):
-                await on_event(Thinking(text=block.thinking))
+        message_to_user = await self._emit_step_events(message, parsed, on_event)
 
         with self.message_history:
             self.message_history.add_assistant(message.content)
@@ -220,10 +245,7 @@ class Agent:
                 await self._execute_tools(parsed.tool_calls, stats, trace, on_event)
 
         trace.end_turn()
-        return TurnResult(
-            message_to_user=self._collect_text(parsed.text_blocks),
-            has_tool_calls=bool(parsed.tool_calls),
-        )
+        return TurnResult(message_to_user=message_to_user, has_tool_calls=bool(parsed.tool_calls))
 
     async def execute(self, user_request: str, on_event: Listener = noop) -> AgentExecuteResult:
         """Execute user request.

--- a/baski/agents/events.py
+++ b/baski/agents/events.py
@@ -16,6 +16,7 @@ class EventType(StrEnum):
 
     TURN_STARTED = "turn_started"
     THINKING = "thinking"
+    MESSAGE = "message"
     TOOL_STARTED = "tool_started"
     TOOL_FINISHED = "tool_finished"
     COMPLETED = "completed"
@@ -32,6 +33,13 @@ class Thinking(BaseModel):
     """The model produced extended-thinking text this turn (may be long)."""
 
     type: EventType = EventType.THINKING
+    text: str
+
+
+class Message(BaseModel):
+    """The model produced user-facing text mid-run (narration before its tool calls)."""
+
+    type: EventType = EventType.MESSAGE
     text: str
 
 
@@ -59,7 +67,7 @@ class Completed(BaseModel):
     response: str | None
 
 
-AgentEvent = TurnStarted | Thinking | ToolStarted | ToolFinished | Completed
+AgentEvent = TurnStarted | Thinking | Message | ToolStarted | ToolFinished | Completed
 
 # A listener is any async callable that consumes one event. Compose several by
 # wrapping them in one function; the agent takes a single listener for simplicity.

--- a/baski/agents/tools/knowledge.py
+++ b/baski/agents/tools/knowledge.py
@@ -71,8 +71,16 @@ Use aggressively - store first, synthesize later. More is better than perfect.""
         """Initialize an empty knowledge store."""
         self.knowledge: list[str] = []
 
-    async def execute(self, facts: list[str]) -> str:  # type: ignore[override]
-        """Store facts and return confirmation."""
+    async def execute(self, facts: list[str] | str) -> str:  # type: ignore[override]
+        """Store facts and return confirmation.
+
+        The model often sends `facts` as one newline-joined string instead of the
+        array the schema asks for. Split it into lines — otherwise `extend` iterates
+        the string character-by-character, storing each char as its own "fact" and
+        flooding the context with thousands of single-letter bullets.
+        """
+        if isinstance(facts, str):
+            facts = [line.strip() for line in facts.splitlines() if line.strip()]
         self.knowledge.extend(facts)
         stored = len(facts)
         total = len(self.knowledge)

--- a/baski/clients/scheduler.py
+++ b/baski/clients/scheduler.py
@@ -1,0 +1,90 @@
+"""Cloud Tasks-backed scheduler for enqueuing HTTP tasks (immediate or delayed)."""
+
+__all__ = ["CloudTasksConfig", "CloudTasksScheduler", "Scheduler"]
+
+from typing import Protocol
+
+from google.api_core.exceptions import AlreadyExists
+from google.cloud import tasks_v2
+from google.protobuf import timestamp_pb2
+from pydantic import BaseModel
+
+from ..primitives import datetime
+
+
+class Scheduler(Protocol):
+    """Protocol for task schedulers that enqueue HTTP tasks."""
+
+    async def enqueue(  # noqa: PLR0913 — an HTTP task legitimately needs endpoint, name, body, headers, schedule
+        self,
+        *,
+        endpoint: str,
+        task_name: str,
+        payload: bytes,
+        headers: dict[str, str] | None = None,
+        schedule_time: datetime.datetime | None = None,
+    ) -> bool:
+        """Enqueue an HTTP POST task with `payload` as the raw body; immediate when schedule_time is None.
+
+        `headers` default to `Content-Type: application/json` when None. Returns True if
+        the task was created, False if one with this name already exists (dedup). Raises
+        on any other error (fail-loud per project convention).
+        """
+        ...
+
+
+class CloudTasksConfig(BaseModel):
+    """Connection settings for CloudTasksScheduler."""
+
+    model_config = {"arbitrary_types_allowed": True}
+
+    client: tasks_v2.CloudTasksAsyncClient
+    project_id: str
+    location: str
+    queue: str
+    invoker_sa_email: str
+
+
+class CloudTasksScheduler:
+    """Cloud Tasks-backed scheduler. One long-lived client per server instance."""
+
+    def __init__(self, config: CloudTasksConfig) -> None:
+        """Unpack Cloud Tasks connection settings from the config bundle."""
+        self._client = config.client
+        self._project_id = config.project_id
+        self._location = config.location
+        self._queue = config.queue
+        self._invoker_sa_email = config.invoker_sa_email
+
+    async def enqueue(  # noqa: PLR0913 — an HTTP task legitimately needs endpoint, name, body, headers, schedule
+        self,
+        *,
+        endpoint: str,
+        task_name: str,
+        payload: bytes,
+        headers: dict[str, str] | None = None,
+        schedule_time: datetime.datetime | None = None,
+    ) -> bool:
+        """Create an HTTP task POSTing payload to endpoint; False if task_name already exists."""
+        parent = self._client.queue_path(self._project_id, self._location, self._queue)
+        task = tasks_v2.Task(
+            name=f"{parent}/tasks/{task_name}",
+            http_request=tasks_v2.HttpRequest(
+                http_method=tasks_v2.HttpMethod.POST,
+                url=endpoint,
+                headers=headers if headers is not None else {"Content-Type": "application/json"},
+                body=payload,
+                oidc_token=tasks_v2.OidcToken(service_account_email=self._invoker_sa_email),
+            ),
+        )
+        if schedule_time is not None:
+            ts = timestamp_pb2.Timestamp()
+            ts.FromDatetime(schedule_time)
+            task.schedule_time = ts
+
+        try:
+            await self._client.create_task(parent=parent, task=task)
+        except AlreadyExists:
+            return False
+        else:
+            return True

--- a/baski/infra/run.py
+++ b/baski/infra/run.py
@@ -10,6 +10,7 @@ import pulumi_gcp as gcp
 __all__ = [
     "CloudRunService",
     "CloudRunServiceConfig",
+    "create_cloud_run_env",
     "create_cloud_run_secret_env",
     "create_cloud_run_with_monitoring",
     "repo_sha",
@@ -41,6 +42,11 @@ class CloudRunServiceConfig:
     ingress: str = "INGRESS_TRAFFIC_INTERNAL_LOAD_BALANCER"
     min_instances: int = 0
     max_instances: int = 8
+
+
+def create_cloud_run_env(name: str, value: str) -> gcp.cloudrunv2.ServiceTemplateContainerEnvArgs:
+    """Return a Cloud Run env-var args object with a plain literal value."""
+    return gcp.cloudrunv2.ServiceTemplateContainerEnvArgs(name=name, value=value)
 
 
 def create_cloud_run_secret_env(secret_id: str, service_name: str) -> gcp.cloudrunv2.ServiceTemplateContainerEnvArgs:

--- a/baski/telegram/server.py
+++ b/baski/telegram/server.py
@@ -3,9 +3,11 @@
 import abc
 import argparse
 import asyncio
+import json
 from collections.abc import AsyncIterator, Iterable
 from contextlib import asynccontextmanager
 from functools import cached_property
+from http import HTTPStatus
 from typing import Any
 from urllib.parse import urlparse
 
@@ -18,11 +20,14 @@ from fastapi import FastAPI, Request, Response
 from hypercorn.asyncio import serve
 from hypercorn.config import Config as HypercornConfig
 
+from ..clients.scheduler import CloudTasksConfig, CloudTasksScheduler
 from ..env import get_env
 from ..pattern import retry
 from ..server.async_server import AsyncServer
 
 __all__ = ["TelegramServer"]
+
+_WORKER_PATH = "/tasks/update"
 
 
 class TelegramServer(AsyncServer):
@@ -53,6 +58,19 @@ class TelegramServer(AsyncServer):
     def add_webhook_routes(self, app: FastAPI) -> None:
         """Hook for subclasses to add extra HTTP routes alongside the webhook endpoint."""
 
+    def cloud_tasks_config(self) -> CloudTasksConfig:
+        """Return Cloud Tasks settings for the inbound-update queue.
+
+        Override to run in webhook mode — baski imposes no project, region, queue, or
+        service-account convention; the app supplies them (DI seam, like `routers()`).
+        """
+        raise NotImplementedError("Override cloud_tasks_config() to run in webhook mode")
+
+    @cached_property
+    def _scheduler(self) -> CloudTasksScheduler:
+        """Cloud Tasks enqueuer for inbound updates (webhook mode only)."""
+        return CloudTasksScheduler(self.cloud_tasks_config())
+
     @cached_property
     def bot(self) -> Bot:
         """Construct the `Bot` instance from the `--token` CLI arg."""
@@ -71,7 +89,7 @@ class TelegramServer(AsyncServer):
     def add_arguments(self, parser: argparse.ArgumentParser) -> None:
         """Register CLI arguments for webhook URL and bot token."""
         super().add_arguments(parser)
-        parser.add_argument("--webhook-path", default=str(get_env("WEBHOOK_URL", "")), help="Public webhook URL")
+        parser.add_argument("--webhook-url", default=str(get_env("WEBHOOK_URL", "")), help="Public webhook URL")
         parser.add_argument("--token", default=str(get_env("TELEGRAM_TOKEN", "")), help="Telegram bot token")
 
     def execute(self) -> int:
@@ -88,9 +106,11 @@ class TelegramServer(AsyncServer):
         asyncio.run(main())
         return 0
 
-    def _run_webhook(self) -> int:
-        webhook_url = self.args["webhook_path"]
-        path = urlparse(webhook_url).path or "/webhook"
+    def _run_webhook(self) -> int:  # noqa: PLR0915 — wires startup + webhook/worker/ping routes inline
+        webhook_url = self.args["webhook_url"]
+        parsed = urlparse(webhook_url)
+        path = parsed.path or "/webhook"
+        worker_url = f"{parsed.scheme}://{parsed.netloc}{_WORKER_PATH}"
 
         @asynccontextmanager
         async def lifespan(_: FastAPI) -> AsyncIterator[None]:
@@ -108,9 +128,22 @@ class TelegramServer(AsyncServer):
 
         @app.post(path)
         async def webhook(request: Request) -> Response:
+            # Enqueue and answer 200 at once. Running the agent inline blows past Telegram's
+            # ~60s webhook timeout, which re-delivers the same update_id and double-processes.
+            # Forward Telegram's exact bytes; parse only to peek update_id for the dedup name.
+            raw = await request.body()
+            await self._scheduler.enqueue(
+                endpoint=worker_url,
+                task_name=f"tg-update-{json.loads(raw)['update_id']}",
+                payload=raw,
+            )
+            return Response(status_code=HTTPStatus.OK)
+
+        @app.post(_WORKER_PATH)
+        async def process_task(request: Request) -> Response:
             update = Update.model_validate(await request.json(), context={"bot": self.bot})
             await self.dp.feed_webhook_update(self.bot, update)
-            return Response(status_code=200)
+            return Response(status_code=HTTPStatus.OK)
 
         @app.get("/")
         @app.get("/ping")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "baski"
-version = "0.5.0"
+version = "0.6.0"
 description = "Shared foundation library: primitives, patterns, FastAPI server, GCP integrations, Telegram framework."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -242,7 +242,7 @@ wheels = [
 
 [[package]]
 name = "baski"
-version = "0.5.0"
+version = "0.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },


### PR DESCRIPTION
## Why

Production Telegram bots on this framework were **processing each message twice** and sometimes replying *"couldn't produce a response"* after thinking for a long time. Tracing it surfaced three distinct bugs (one per area below). Bumps `0.5.0 → 0.6.0`.

## What

### Non-blocking webhook (the duplicate-processing bug)
Webhook mode awaited the full agent loop *inline* before returning `200`. Long replies blew past Telegram's ~60s webhook timeout, so Telegram **re-delivered the same `update_id`** and the agent ran again — duplicate traces, duplicate answers.

Now the webhook **enqueues the raw update bytes to Cloud Tasks and returns `200` immediately**; a worker route (`/tasks/update`) processes it off-request.
- Dedup is free: task name = `tg-update-{update_id}` → a re-delivery is `AlreadyExists` and dropped.
- New `baski.clients.scheduler` (`CloudTasksScheduler` / `Scheduler` / `CloudTasksConfig`), ported from clarity, FastAPI-glue removed, `payload: bytes` passthrough + optional `headers`/`schedule_time`.
- DI seam: `TelegramServer.cloud_tasks_config()` — baski imposes **no** project/region/queue/SA convention; the app supplies them (raises if unimplemented; only needed in webhook mode). Polling is untouched.

### Agent: surface refusals (the empty-reply bug)
`stop_reason: "refusal"` was silently indistinguishable from a normal finish → empty reply. Now raises `AgentRefusalError` so callers can handle it instead of returning nothing.

### KnowledgeTool: stop shredding string facts (the root cause of the refusals)
The model sends `facts` as one newline-joined string; `extend()` iterated it **character-by-character**, storing each char as a "fact" and flooding the context with thousands of single-letter bullets — which tripped the safety classifier into the refusals above. Now a string is split on newlines.

### Live narration
New `Message` agent event for mid-run, pre-tool narration text, so listeners (e.g. a Telegram progress view) can show it live instead of only the final answer.

### infra
`create_cloud_run_env(name, value)` helper for plain Cloud Run env vars (parallel to `create_cloud_run_secret_env`).

## Notes
- `_run_webhook` / `enqueue` carry justified `# noqa` (PLR0915/PLR0913) consistent with `infra/queue.py`.
- Webhook mode now **requires** a `cloud_tasks_config()` override — a breaking change for any webhook subclass (none in tree besides the nisse consumer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
