### PR TITLE
Agent framework: DI, ToolSet/ShortTermMemory, input validation, two-mode loop (v0.6.1)

### DIFF
--- a/baski/agents/CLAUDE.md
+++ b/baski/agents/CLAUDE.md
@@ -5,49 +5,28 @@ Ported from clarity-auto-care; the generic core lives here so other projects (e.
 
 ## Core Components
 
-- `Agent`: Main agent loop — streaming responses, parallel tool execution, conversation flow. Creates `ToolBox` internally. Auto-injects `KnowledgeTool` and `DeleteMessagesTool`.
-- `ToolBox`: Registry + parallel executor (`asyncio.gather`) for a set of tools.
-- `Tool`: Abstract base — define `name`, `one_line`, `description`, `input_schema`, implement `async execute(**kwargs) -> str`.
-- `MessageHistory`: Conversation history with context-window truncation (64k tokens default, truncates at 90%).
-- `TraceCollector` (`trace.py`): Persists turn-by-turn traces to GCS (gzipped JSON) + a Mongo `traces` summary collection.
-- `AgentExecuteResult`: Pydantic result (trace id, tokens, turn/tool counts, cost).
+- `Agent` (`agent.py`): the agentic loop. Constructs nothing — the caller passes collaborators via `AgentConfig` plus an `on_event` listener.
+- `ToolSet` (`toolset.py`): tool registry + parallel executor; validates each call against the tool's `Input` model; `system_prompt()` aggregates the roster + per-tool contributions.
+- `Tool` (`tool.py`): abstract base. A tool declares `name`/`one_line`/`description`, a nested `Input(BaseModel)`, and `async execute(**kwargs) -> str`; optional `system_prompt()`.
+- `MessageHistory` (`message_history.py`): transcript with context-window truncation.
+- `TraceCollector` (`trace.py`): turn-by-turn traces → GCS + Mongo `traces`.
+- `AgentExecuteResult` (`execute_result.py`): pydantic result (trace id, tokens, counts, cost).
 
 ## Built-in Tools (`tools/`)
 
-Auto-injected by `Agent`:
-- `KnowledgeTool` (`store_knowledge`): preserve facts across context truncation.
-- `DeleteMessagesTool` (`delete_messages`): drop turns by id to free context.
+The caller wires these into the `ToolSet` (not auto-injected):
+- `ShortTermMemory` (`store_memory`): per-run fact scratchpad; also passed as `AgentConfig.short_term_memory`.
+- `DeleteMessagesTool` (`delete_messages`): drop turns by id; built with the shared `MessageHistory`.
+- `GoogleSearchTool`, `YelpSearchTool`, `GooglePlayTool`, `AppleAppStoreTool` (SerpApi), `WebBrowseTool` (Playwright).
 
-Opt-in, generic (pass via `AgentConfig.tools`):
-- `GoogleSearchTool`, `YelpSearchTool`, `GooglePlayTool`, `AppleAppStoreTool` — via `baski.clients.serpapi_client`.
-- `WebBrowseTool` — via `baski.clients.playwright_client`.
-
-Project-specific tools (DB lookups, formatters) stay in the consuming project, NOT here.
+Project-specific tools stay in the consuming project, NOT here. Canonical assembly: nisse `app/assistant/assistant.py`.
 
 ## Dependencies on baski
 
-Imports map to baski foundation: `baski.primitives.datetime`, `baski.primitives.json`,
-`baski.concurrent.as_async`, `baski.server.Logger`, `baski.clients.*`.
-
-## Usage
-
-```python
-from baski.agents import Agent, AgentConfig
-from baski.agents.tools import GoogleSearchTool
-
-config = AgentConfig(
-    logger=logger,
-    tools=[GoogleSearchTool(serpapi_client=serpapi_client)],
-    anthropic_client=anthropic_client,
-    database=database,          # pymongo AsyncDatabase — trace summaries
-    bucket_name="my-traces",    # GCS bucket for full traces (parameterized, no hardcoded default)
-    # model defaults to DEFAULT_MODEL ("claude-opus-4-8"); override per-agent if needed
-)
-result = await Agent(config=config).execute("user request")
-```
+`baski.primitives.{datetime,json}`, `baski.concurrent.as_async`, `baski.server.Logger`, `baski.clients.*`.
 
 ## Notes
 
 - Tracing is mandatory: every `execute()` requires a Mongo `database` and a GCS `bucket_name`.
 - Extended thinking is `adaptive`; parallel tool use enabled; `max_tokens=128_000`.
-- The clarity FastAPI trace-browser router (`router.py` / `get_trace_flow.py`) was NOT ported — it is deployment-specific. Add a thin router in the consuming project if a trace UI is needed.
+- The clarity FastAPI trace-browser router was NOT ported — deployment-specific. Add a thin router in the consuming project if a trace UI is needed.

--- a/baski/agents/__init__.py
+++ b/baski/agents/__init__.py
@@ -16,7 +16,7 @@ from .events import (
 from .execute_result import AgentExecuteResult
 from .message_history import MessageHistory
 from .tool import Tool
-from .toolbox import ToolBox
+from .toolset import ToolSet
 
 __all__ = [
     "Agent",
@@ -31,8 +31,8 @@ __all__ = [
     "MessageHistory",
     "Thinking",
     "Tool",
-    "ToolBox",
     "ToolFinished",
+    "ToolSet",
     "ToolStarted",
     "TurnStarted",
     "noop",

--- a/baski/agents/agent.py
+++ b/baski/agents/agent.py
@@ -17,12 +17,16 @@ from .events import Message as MessageEvent
 from .execute_result import AgentExecuteResult
 from .message_history import MessageHistory
 from .pricing import ExecutionStats
-from .tool import Tool
-from .toolbox import ToolBox
-from .tools import DeleteMessagesTool, KnowledgeTool
+from .tools import ShortTermMemory
+from .toolset import ToolSet
 from .trace import TraceCollector, TraceCollectorConfig
 
 DEFAULT_MODEL = "claude-opus-4-8"
+
+AGENT_LOOP_GUIDANCE = (
+    "Always use the most appropriate tool. Use parallel tool calls when they are independent\n"
+    "Provide brief explanation of your reasoning for when you use tools and what are next steps."
+)
 
 
 class AgentRefusalError(RuntimeError):
@@ -48,56 +52,51 @@ class TurnResult(NamedTuple):
 
 
 class AgentConfig(NamedTuple):
-    """Configuration parameters for Agent initialization."""
+    """Configuration parameters for Agent initialization.
+
+    The caller assembles the collaborators (`toolset`, `message_history`,
+    `short_term_memory`) and passes them in — the Agent constructs nothing. The
+    `short_term_memory` instance must also be present in the `toolset` so the model
+    can call it; the separate field gives the Agent typed access for per-turn
+    knowledge injection.
+    """
 
     logger: Logger
-    tools: list[Tool]
+    toolset: ToolSet
+    message_history: MessageHistory
+    short_term_memory: ShortTermMemory
     anthropic_client: AsyncAnthropic
     database: AsyncDatabase
     bucket_name: str
+    system_prompt: str
     model: str = DEFAULT_MODEL
 
 
 class Agent:
-    """Stateful agent with agentic loop handling tool execution and conversation management.
+    """Stateful agent with agentic loop handling tool execution and conversation management."""
 
-    KnowledgeTool is automatically injected.
-    """
+    def __init__(self, config: AgentConfig, on_event: Listener = noop, **params: object) -> None:
+        """Initialize agent with config, a step-event listener, and optional API overrides.
 
-    def __init__(self, config: AgentConfig, **params: object) -> None:
-        """Initialize agent with config and optional API parameter overrides."""
+        `on_event` is an async listener that receives step events (turn start, thinking,
+        tool start/finish, completion) as the loop runs — the seam for live progress UIs.
+        The agent stays transport-agnostic; the listener owns rendering.
+        """
         self.logger = config.logger
         self.database = config.database
         self.bucket_name = config.bucket_name
-        self.message_history = MessageHistory(logger=config.logger)
         self.anthropic_client = config.anthropic_client
+        self.message_history = config.message_history
+        self.toolset = config.toolset
+        self.short_term_memory = config.short_term_memory
+        self.on_event = on_event
 
-        self.toolbox = ToolBox(logger=config.logger)
-        self.knowledge_tool = KnowledgeTool()
-        for tool in config.tools:
-            self.toolbox.add(tool)
-        self.toolbox.add(self.knowledge_tool)
-        self.toolbox.add(DeleteMessagesTool(self.message_history))
-
-        actual_system_prompt = (
-            f"You have tools:\n"
-            f"{self.toolbox.short_description()}\n"
-            f"\n"
-            f"IMPORTANT: Use store_knowledge tool proactively to preserve important information.\n"
-            f"Store knowledge immediately after learning new facts to prevent loss during conversation.\n"
-            f"\n"
-            f"CONTEXT MANAGEMENT: After storing knowledge, delete the source turns with delete_messages"
-            f" to free context space.\n"
-            f"Workflow: search → store_knowledge → delete_messages for the turns you just stored.\n"
-            f"\n"
-            f"Always use the most appropriate tool. Use parallel tool calls when they are independent\n"
-            f"Provide brief explanation of your reasoning for when you use tools and what are next steps."
-        )
+        system = f"{config.system_prompt}\n\n{self.toolset.system_prompt()}\n\n{AGENT_LOOP_GUIDANCE}"
 
         self.params: dict[str, object] = {
-            "system": actual_system_prompt,
+            "system": system,
             "model": config.model,
-            "tools": self.toolbox.format_for_api(),
+            "tools": self.toolset.format_for_api(),
             "tool_choice": {"type": "auto", "disable_parallel_tool_use": False},
             "thinking": {"type": "adaptive"},
             "max_tokens": 128_000,
@@ -165,12 +164,12 @@ class Agent:
         return [
             user_request_message,
             time_message,
-            self.knowledge_tool.format_as_user_message(),
+            self.short_term_memory.format_as_user_message(),
             *self.message_history.format_for_api(),
         ]
 
     async def _execute_tools(
-        self, tool_calls: list[ToolUseBlock], stats: ExecutionStats, trace: TraceCollector, on_event: Listener
+        self, tool_calls: list[ToolUseBlock], stats: ExecutionStats, trace: TraceCollector
     ) -> None:
         """Execute tool calls and record results in history and trace."""
         stats.tool_calls += len(tool_calls)
@@ -178,20 +177,22 @@ class Agent:
             "Tools execution", labels={"toolCount": len(tool_calls), "tools": [tc.name for tc in tool_calls]}
         )
         for tc in tool_calls:
-            await on_event(ToolStarted(name=tc.name, tool_input=dict(tc.input) if isinstance(tc.input, dict) else {}))
+            await self.on_event(
+                ToolStarted(name=tc.name, tool_input=dict(tc.input) if isinstance(tc.input, dict) else {})
+            )
 
-        tool_results = await self.toolbox.execute(tool_calls)
+        tool_results = await self.toolset.execute(tool_calls)
         self.message_history.add_tool_results(tool_results)
-        trace.record_tool_results(tool_results, self.toolbox.last_timings)
+        trace.record_tool_results(tool_results, self.toolset.last_timings)
 
         name_by_id = {tc.id: tc.name for tc in tool_calls}
         for result in tool_results:
             tool_id = result["tool_use_id"]
-            await on_event(
+            await self.on_event(
                 ToolFinished(
                     name=name_by_id.get(tool_id, ""),
                     ok=not result.get("is_error", False),
-                    duration_ms=self.toolbox.last_timings.get(tool_id, 0),
+                    duration_ms=self.toolset.last_timings.get(tool_id, 0),
                 )
             )
 
@@ -203,7 +204,7 @@ class Agent:
         self.logger.info("Text received", labels={"message_to_user": message_to_user})
         return message_to_user
 
-    async def _emit_step_events(self, message: Message, parsed: ParsedResponse, on_event: Listener) -> str | None:
+    async def _emit_step_events(self, message: Message, parsed: ParsedResponse) -> str | None:
         """Surface this turn's thinking and pre-tool narration to the listener; return the text.
 
         Narration before tool calls is user-facing; the final turn's text (no tool calls) is
@@ -211,14 +212,14 @@ class Agent:
         """
         for block in message.content:
             if isinstance(block, ThinkingBlock):
-                await on_event(Thinking(text=block.thinking))
+                await self.on_event(Thinking(text=block.thinking))
         text = self._collect_text(parsed.text_blocks)
         if text and parsed.tool_calls:
-            await on_event(MessageEvent(text=text))
+            await self.on_event(MessageEvent(text=text))
         return text
 
     async def _run_turn(
-        self, user_request_message: MessageParam, stats: ExecutionStats, trace: TraceCollector, on_event: Listener
+        self, user_request_message: MessageParam, stats: ExecutionStats, trace: TraceCollector
     ) -> TurnResult:
         """Run a single agentic turn: build messages, call API, parse response, execute tools."""
         messages = self._build_messages(user_request_message)
@@ -229,7 +230,7 @@ class Agent:
         api_duration_ms = int((time.monotonic() - start) * 1000)
 
         stats.collect(message.usage)
-        await on_event(TurnStarted(turn=stats.turn_count))
+        await self.on_event(TurnStarted(turn=stats.turn_count))
         if len(self.message_history) == 0 and message.usage.input_tokens > self.message_history.max_tokens // 2:
             raise RuntimeError("Initial context is too large. Try to provide more LLM context.")
 
@@ -237,25 +238,22 @@ class Agent:
         parsed = self._parse_response(message.content)
         trace.record_response(message, api_duration_ms)
 
-        message_to_user = await self._emit_step_events(message, parsed, on_event)
+        message_to_user = await self._emit_step_events(message, parsed)
 
         with self.message_history:
             self.message_history.add_assistant(message.content)
             if parsed.tool_calls:
-                await self._execute_tools(parsed.tool_calls, stats, trace, on_event)
+                await self._execute_tools(parsed.tool_calls, stats, trace)
 
         trace.end_turn()
         return TurnResult(message_to_user=message_to_user, has_tool_calls=bool(parsed.tool_calls))
 
-    async def execute(self, user_request: str, on_event: Listener = noop) -> AgentExecuteResult:
+    async def execute(self, user_request: str) -> AgentExecuteResult:
         """Execute user request.
 
         It can be called multiple times however the context is preserved. Each following
-        call will have context from previous calls.
-
-        `on_event` is an optional async listener that receives step events (turn start,
-        thinking, tool start/finish, completion) as the loop runs — the seam for live
-        progress UIs. The agent stays transport-agnostic; the listener owns rendering.
+        call will have context from previous calls. Step events go to the `on_event`
+        listener passed to the constructor.
         """
         user_request_message = MessageParam(
             role="user", content=[TextBlockParam(type="text", text=f"YOUR TASK IS: {user_request}")]
@@ -277,14 +275,14 @@ class Agent:
         turn = TurnResult(message_to_user=None, has_tool_calls=False)
         try:
             while True:
-                turn = await self._run_turn(user_request_message, stats, trace, on_event)
+                turn = await self._run_turn(user_request_message, stats, trace)
                 if not turn.has_tool_calls:
                     break
         except Exception as e:
             trace.finalize(stats, error=str(e))
             raise
 
-        await on_event(Completed(response=turn.message_to_user))
+        await self.on_event(Completed(response=turn.message_to_user))
 
         self.logger.info(
             "Agent execution complete",

--- a/baski/agents/agent.py
+++ b/baski/agents/agent.py
@@ -90,6 +90,8 @@ class Agent:
         self.toolset = config.toolset
         self.short_term_memory = config.short_term_memory
         self.on_event = on_event
+        # Not in message_history.turns, so truncate/delete_messages can't reach it.
+        self._pinned: list[MessageParam] = []
 
         system = f"{config.system_prompt}\n\n{self.toolset.system_prompt()}\n\n{AGENT_LOOP_GUIDANCE}"
 
@@ -101,6 +103,14 @@ class Agent:
             "thinking": {"type": "adaptive"},
             "max_tokens": 128_000,
         } | params
+
+    def add_pinned(self, message: MessageParam) -> None:
+        """Pin a message to the top of every turn, protected from truncation/deletion."""
+        self._pinned.append(message)
+
+    def add_pinned_text(self, text: str) -> None:
+        """Pin a plain user-text message (e.g. a one-shot task framed for the model)."""
+        self.add_pinned(MessageParam(role="user", content=[TextBlockParam(type="text", text=text)]))
 
     async def _call_api(self, messages: list[MessageParam]) -> Message:
         """Streaming API call with retry on api_error (max 1 retry, 2s sleep).
@@ -154,15 +164,15 @@ class Agent:
 
         return ParsedResponse(tool_calls=tool_calls, text_blocks=text_blocks)
 
-    def _build_messages(self, user_request_message: MessageParam) -> list[MessageParam]:
-        """Build the full message list for an API call."""
+    def _build_messages(self) -> list[MessageParam]:
+        """Build the full message list for an API call: pinned context, then the history."""
         now = datetime.now()
         time_message = MessageParam(
             role="user",
             content=[TextBlockParam(type="text", text=f"Current time: {now.strftime('%A, %B %d, %Y %I:%M %p %Z')}")],
         )
         return [
-            user_request_message,
+            *self._pinned,
             time_message,
             self.short_term_memory.format_as_user_message(),
             *self.message_history.format_for_api(),
@@ -218,11 +228,9 @@ class Agent:
             await self.on_event(MessageEvent(text=text))
         return text
 
-    async def _run_turn(
-        self, user_request_message: MessageParam, stats: ExecutionStats, trace: TraceCollector
-    ) -> TurnResult:
+    async def _run_turn(self, stats: ExecutionStats, trace: TraceCollector) -> TurnResult:
         """Run a single agentic turn: build messages, call API, parse response, execute tools."""
-        messages = self._build_messages(user_request_message)
+        messages = self._build_messages()
         trace.start_turn(messages)
 
         start = time.monotonic()
@@ -248,22 +256,34 @@ class Agent:
         trace.end_turn()
         return TurnResult(message_to_user=message_to_user, has_tool_calls=bool(parsed.tool_calls))
 
-    async def execute(self, user_request: str) -> AgentExecuteResult:
-        """Execute user request.
+    def _request_label(self) -> str:
+        """Short label for traces/logs: the newest user text, from history then pinned."""
+        history_messages = [m for turn in self.message_history.turns for m in turn.messages]
+        for message in reversed(self._pinned + history_messages):
+            if message["role"] != "user":
+                continue
+            content = message["content"]
+            if isinstance(content, list):
+                for block in content:
+                    if isinstance(block, dict) and block.get("type") == "text":
+                        return str(block.get("text", ""))
+        return ""
 
-        It can be called multiple times however the context is preserved. Each following
-        call will have context from previous calls. Step events go to the `on_event`
-        listener passed to the constructor.
+    async def execute(self) -> AgentExecuteResult:
+        """Drive the agentic loop over the current pinned context + history until done.
+
+        The caller sets up the request before calling: pin a task with `add_pinned_text`
+        (task mode), or add the message to the injected `message_history` (chat mode, which
+        also lets the loop continue a prior conversation). Re-callable — context is
+        preserved across calls. Step events go to the constructor's `on_event` listener.
         """
-        user_request_message = MessageParam(
-            role="user", content=[TextBlockParam(type="text", text=f"YOUR TASK IS: {user_request}")]
-        )
-        self.logger.info("Agent execution started", labels={"userRequest": user_request[:100]})
+        label = self._request_label()
+        self.logger.info("Agent execution started", labels={"userRequest": label[:100]})
 
         stats = ExecutionStats(model=str(self.params["model"]))
         trace = TraceCollector(
             config=TraceCollectorConfig(
-                user_request=user_request,
+                user_request=label,
                 model=str(self.params["model"]),
                 system_prompt=str(self.params["system"]),
                 bucket_name=self.bucket_name,
@@ -275,7 +295,7 @@ class Agent:
         turn = TurnResult(message_to_user=None, has_tool_calls=False)
         try:
             while True:
-                turn = await self._run_turn(user_request_message, stats, trace)
+                turn = await self._run_turn(stats, trace)
                 if not turn.has_tool_calls:
                     break
         except Exception as e:
@@ -286,7 +306,7 @@ class Agent:
 
         self.logger.info(
             "Agent execution complete",
-            labels={"userRequest": user_request[:100], "traceId": trace.id, **stats.for_logs().model_dump()},
+            labels={"userRequest": label[:100], "traceId": trace.id, **stats.for_logs().model_dump()},
         )
 
         result = AgentExecuteResult(

--- a/baski/agents/tool.py
+++ b/baski/agents/tool.py
@@ -4,15 +4,31 @@ from abc import ABC, abstractmethod
 from typing import Any, ClassVar
 
 from anthropic.types import ToolParam
+from pydantic import BaseModel
 
 
 class Tool(ABC):
-    """Base class for all agent tools."""
+    """Base class for all agent tools.
+
+    Every tool declares its argument contract as a nested `Input(BaseModel)`. The JSON
+    schema sent to the API is derived from it, and the agent validates every call
+    against it before running `execute`. A tool with no `Input` fails at
+    class-definition time — the contract is enforced when the class is built, not at
+    runtime.
+    """
 
     name: ClassVar[str]
     one_line: ClassVar[str]
     description: ClassVar[str]
+    Input: ClassVar[type[BaseModel]]
     input_schema: ClassVar[Any]
+
+    def __init_subclass__(cls, **kwargs: object) -> None:
+        """Require a nested `Input` model and derive `input_schema` from it."""
+        super().__init_subclass__(**kwargs)
+        if getattr(cls, "Input", None) is None:
+            raise TypeError(f"{cls.__name__} must define a nested `Input(BaseModel)` describing its arguments")
+        cls.input_schema = cls.Input.model_json_schema()
 
     def __hash__(self) -> int:
         """Hash by tool name for use in sets and dicts."""
@@ -29,6 +45,10 @@ class Tool(ABC):
             description=self.description,
             input_schema=self.input_schema,
         )
+
+    def system_prompt(self) -> str:
+        """Extra instructions this tool adds to the agent system prompt. None by default."""
+        return ""
 
     @abstractmethod
     async def execute(self, **kwargs: object) -> str:

--- a/baski/agents/tools/__init__.py
+++ b/baski/agents/tools/__init__.py
@@ -4,7 +4,7 @@ from .apple_app_store import AppleAppStoreTool
 from .delete_messages import DeleteMessagesTool
 from .google_play import GooglePlayTool
 from .google_search import GoogleSearchTool
-from .knowledge import KnowledgeTool
+from .short_term_memory import ShortTermMemory
 from .web_browse import WebBrowseTool
 from .yelp_search import YelpSearchTool
 
@@ -13,7 +13,7 @@ __all__ = [
     "DeleteMessagesTool",
     "GooglePlayTool",
     "GoogleSearchTool",
-    "KnowledgeTool",
+    "ShortTermMemory",
     "WebBrowseTool",
     "YelpSearchTool",
 ]

--- a/baski/agents/tools/apple_app_store.py
+++ b/baski/agents/tools/apple_app_store.py
@@ -1,6 +1,6 @@
 """Tool for fetching Apple App Store data via SerpApi."""
 
-from typing import Any, ClassVar
+from pydantic import BaseModel, Field
 
 from baski.clients.serpapi_client import SerpApiClient
 from baski.server import Logger
@@ -17,13 +17,11 @@ class AppleAppStoreTool(Tool):
         "Fetch Apple App Store data by searching for company/app name. "
         "Returns app information including title, rating, developer, and description."
     )
-    input_schema: ClassVar[Any] = {
-        "type": "object",
-        "properties": {
-            "company_name": {"type": "string", "description": "Company or app name to search for (e.g., 'Zibra AI')"}
-        },
-        "required": ["company_name"],
-    }
+
+    class Input(BaseModel):
+        """Arguments for an App Store lookup."""
+
+        company_name: str = Field(description="Company or app name to search for (e.g., 'Zibra AI')")
 
     def __init__(self, serpapi_client: SerpApiClient, logger: Logger) -> None:
         """Store SerpApi client and logger."""

--- a/baski/agents/tools/delete_messages.py
+++ b/baski/agents/tools/delete_messages.py
@@ -1,6 +1,6 @@
 """Tool for deleting conversation turns from message history."""
 
-from typing import Any, ClassVar
+from pydantic import BaseModel, Field
 
 from ..message_history import MessageHistory
 from ..tool import Tool
@@ -13,21 +13,14 @@ class DeleteMessagesTool(Tool):
     one_line = "Delete old messages to free context window"
     description = """Delete turns from conversation history by [Turn N] IDs visible in messages.
 
-Use after store_knowledge to remove turns whose content is already preserved.
+Use after store_memory to remove turns whose content is already preserved.
 Old search results may contain outdated info — delete to avoid misleading context.
 Tool result turns are the largest — prioritize deleting those."""
 
-    input_schema: ClassVar[Any] = {
-        "type": "object",
-        "properties": {
-            "turn_ids": {
-                "type": "array",
-                "items": {"type": "integer"},
-                "description": "Turn IDs to delete (visible as [Turn N] in messages)",
-            }
-        },
-        "required": ["turn_ids"],
-    }
+    class Input(BaseModel):
+        """Arguments for deleting conversation turns."""
+
+        turn_ids: list[int] = Field(description="Turn IDs to delete (visible as [Turn N] in messages)")
 
     def __init__(self, message_history: MessageHistory) -> None:
         """Store reference to the shared message history."""
@@ -37,3 +30,11 @@ Tool result turns are the largest — prioritize deleting those."""
         """Delete specified turns and return removal count."""
         removed = self.message_history.delete_turns(turn_ids)
         return f"Deleted {removed} message(s). Remaining: {len(self.message_history)} messages."
+
+    def system_prompt(self) -> str:
+        """Instructions telling the agent to free context after storing knowledge."""
+        return (
+            "CONTEXT MANAGEMENT: After storing knowledge, delete the source turns with "
+            "delete_messages to free context space.\n"
+            "Workflow: search → store_memory → delete_messages for the turns you just stored."
+        )

--- a/baski/agents/tools/google_play.py
+++ b/baski/agents/tools/google_play.py
@@ -1,6 +1,6 @@
 """Tool for fetching Google Play developer app data via SerpApi."""
 
-from typing import Any, ClassVar
+from pydantic import BaseModel, Field
 
 from baski.clients.serpapi_client import SerpApiClient
 from baski.server import Logger
@@ -16,16 +16,11 @@ class GooglePlayTool(Tool):
     description = (
         "Fetch Google Play developer apps and data using developer ID. Returns list of apps published by the developer."
     )
-    input_schema: ClassVar[Any] = {
-        "type": "object",
-        "properties": {
-            "developer_id": {
-                "type": "string",
-                "description": "Google Play developer ID (e.g., 'Zibra+AI' or 'com.developer.name')",
-            }
-        },
-        "required": ["developer_id"],
-    }
+
+    class Input(BaseModel):
+        """Arguments for a Google Play developer lookup."""
+
+        developer_id: str = Field(description="Google Play developer ID (e.g., 'Zibra+AI' or 'com.developer.name')")
 
     def __init__(self, serpapi_client: SerpApiClient, logger: Logger) -> None:
         """Store SerpApi client and logger."""

--- a/baski/agents/tools/google_search.py
+++ b/baski/agents/tools/google_search.py
@@ -1,6 +1,8 @@
 """Tool for searching the web via Google SerpApi."""
 
-from typing import Any, ClassVar
+from typing import Any
+
+from pydantic import BaseModel, Field
 
 from baski.clients.serpapi_client import SerpApiClient
 
@@ -18,16 +20,13 @@ class GoogleSearchTool(Tool):
         "use exact phrases with '\"exact phrase\"', "
         "or combine terms with 'keyword1 keyword2 -exclude'"
     )
-    input_schema: ClassVar[Any] = {
-        "type": "object",
-        "properties": {
-            "query": {
-                "type": "string",
-                "description": "The search query to execute on Google. Supports operators like site:, intitle:, inurl:",
-            }
-        },
-        "required": ["query"],
-    }
+
+    class Input(BaseModel):
+        """Arguments for a Google search."""
+
+        query: str = Field(
+            description="The search query to execute on Google. Supports operators like site:, intitle:, inurl:"
+        )
 
     def __init__(self, serpapi_client: SerpApiClient) -> None:
         """Store the SerpApi client."""

--- a/baski/agents/tools/short_term_memory.py
+++ b/baski/agents/tools/short_term_memory.py
@@ -1,17 +1,30 @@
-"""Tool for storing knowledge gathered during agent research."""
+"""Short-term memory tool — stores facts gathered during a single agent run."""
 
 from pathlib import Path
-from typing import Any, ClassVar
+from typing import Annotated
 
 from anthropic.types import MessageParam, TextBlockParam
+from pydantic import BaseModel, BeforeValidator, Field
 
 from ..tool import Tool
 
 
-class KnowledgeTool(Tool):
+def _coerce_facts(value: object) -> object:
+    """Split a newline-joined string into lines before validation.
+
+    The model often sends `facts` as one string instead of the array the schema asks
+    for. Splitting here stops `extend` from iterating the string character-by-character
+    and flooding the context with thousands of single-letter "facts".
+    """
+    if isinstance(value, str):
+        return [line.strip() for line in value.splitlines() if line.strip()]
+    return value
+
+
+class ShortTermMemory(Tool):
     """Tool for agent to store knowledge gathered during conversation."""
 
-    name = "store_knowledge"
+    name = "store_memory"
     one_line = "Lightweight tool to preserve context (USE FREQUENTLY)"
     description = """Store facts you discover during research to preserve them when conversation context gets truncated.
 
@@ -55,32 +68,19 @@ BAD EXAMPLES:
 
 Use aggressively - store first, synthesize later. More is better than perfect."""
 
-    input_schema: ClassVar[Any] = {
-        "type": "object",
-        "properties": {
-            "facts": {
-                "type": "array",
-                "items": {"type": "string"},
-                "description": "List of facts with [SOURCE] prefix. Example: '[DECK] Company founded 2020'",
-            }
-        },
-        "required": ["facts"],
-    }
+    class Input(BaseModel):
+        """Arguments for storing short-term memory facts."""
+
+        facts: Annotated[list[str], BeforeValidator(_coerce_facts)] = Field(
+            description="List of facts with [SOURCE] prefix. Example: '[DECK] Company founded 2020'"
+        )
 
     def __init__(self) -> None:
         """Initialize an empty knowledge store."""
         self.knowledge: list[str] = []
 
-    async def execute(self, facts: list[str] | str) -> str:  # type: ignore[override]
-        """Store facts and return confirmation.
-
-        The model often sends `facts` as one newline-joined string instead of the
-        array the schema asks for. Split it into lines — otherwise `extend` iterates
-        the string character-by-character, storing each char as its own "fact" and
-        flooding the context with thousands of single-letter bullets.
-        """
-        if isinstance(facts, str):
-            facts = [line.strip() for line in facts.splitlines() if line.strip()]
+    async def execute(self, facts: list[str]) -> str:  # type: ignore[override]
+        """Store facts and return confirmation."""
         self.knowledge.extend(facts)
         stored = len(facts)
         total = len(self.knowledge)
@@ -113,4 +113,11 @@ Use aggressively - store first, synthesize later. More is better than perfect.""
         return MessageParam(
             role="user",
             content=[TextBlockParam(type="text", text="\n".join(parts))],
+        )
+
+    def system_prompt(self) -> str:
+        """Instructions telling the agent to preserve facts proactively."""
+        return (
+            f"IMPORTANT: Use {self.name} proactively to preserve important information.\n"
+            f"Store knowledge immediately after learning new facts to prevent loss during conversation."
         )

--- a/baski/agents/tools/web_browse.py
+++ b/baski/agents/tools/web_browse.py
@@ -1,9 +1,9 @@
 """Tool for browsing websites and extracting page content as markdown."""
 
 from http import HTTPStatus
-from typing import Any, ClassVar
 
 from httpx import HTTPStatusError, TimeoutException
+from pydantic import BaseModel, Field
 
 from baski.clients.playwright_client import PlaywrightClient
 
@@ -22,13 +22,11 @@ class WebBrowseTool(Tool):
         "Fetch and read content from any website URL. Returns the page content as markdown. "
         "Use this to read articles, documentation, company websites, or any web content."
     )
-    input_schema: ClassVar[Any] = {
-        "type": "object",
-        "properties": {
-            "url": {"type": "string", "description": "The full URL to browse (e.g., 'https://example.com')"}
-        },
-        "required": ["url"],
-    }
+
+    class Input(BaseModel):
+        """Arguments for a website fetch."""
+
+        url: str = Field(description="The full URL to browse (e.g., 'https://example.com')")
 
     def __init__(self, playwright_client: PlaywrightClient) -> None:
         """Store the Playwright client for page fetching."""

--- a/baski/agents/tools/yelp_search.py
+++ b/baski/agents/tools/yelp_search.py
@@ -1,6 +1,6 @@
 """Tool for searching Yelp business listings via SerpApi."""
 
-from typing import Any, ClassVar
+from pydantic import BaseModel, Field
 
 from baski.clients.serpapi_client import SerpApiClient
 
@@ -17,17 +17,12 @@ class YelpSearchTool(Tool):
         "Use this when you need to find restaurants, shops, services, or other local businesses. "
         "Returns ratings, reviews, prices, categories, and links."
     )
-    input_schema: ClassVar[Any] = {
-        "type": "object",
-        "properties": {
-            "query": {"type": "string", "description": "What to search for (e.g. 'auto repair', 'pizza', 'plumber')"},
-            "location": {
-                "type": "string",
-                "description": "Location to search in (e.g. 'San Francisco, CA', 'Belmont, CA')",
-            },
-        },
-        "required": ["query", "location"],
-    }
+
+    class Input(BaseModel):
+        """Arguments for a Yelp business search."""
+
+        query: str = Field(description="What to search for (e.g. 'auto repair', 'pizza', 'plumber')")
+        location: str = Field(description="Location to search in (e.g. 'San Francisco, CA', 'Belmont, CA')")
 
     def __init__(self, serpapi_client: SerpApiClient) -> None:
         """Store the SerpApi client."""

--- a/baski/agents/toolset.py
+++ b/baski/agents/toolset.py
@@ -85,8 +85,7 @@ class ToolSet:
         try:
             kwargs = tool.Input.model_validate(tool_input).model_dump()
         except ValidationError as exc:
-            # Invalid input: skip execute and hand a parsed, per-field message back to the
-            # model so it can fix the arguments. Other parallel calls still run.
+            # Skip execute; hand the parsed error back so the model retries. Sibling calls still run.
             content = _format_validation_error(tool_name, exc)
             self.logger.warning("Tool input invalid", labels={"toolName": tool_name, "error": content})
             self.last_timings[tool_call.id] = 0

--- a/baski/agents/toolset.py
+++ b/baski/agents/toolset.py
@@ -4,17 +4,30 @@ import asyncio
 import time
 
 from anthropic.types import ToolParam, ToolResultBlockParam, ToolUseBlock
+from pydantic import ValidationError
 
 from baski.server import Logger
 
 from .tool import Tool
 
 
-class ToolBox:
+def _format_validation_error(tool_name: str, exc: ValidationError) -> str:
+    """Render a pydantic error as a short, per-field message the model can act on."""
+    lines = [f"Invalid input for tool '{tool_name}'. Fix these and call it again:"]
+    for err in exc.errors():
+        field = ".".join(str(p) for p in err["loc"]) or "(top level)"
+        detail = err["msg"]
+        if "input" in err:
+            detail += f" (received: {err['input']!r})"
+        lines.append(f"- {field}: {detail}")
+    return "\n".join(lines)
+
+
+class ToolSet:
     """Registry and parallel executor for a named set of agent tools."""
 
     def __init__(self, logger: Logger) -> None:
-        """Initialize an empty toolbox with a logger for error reporting."""
+        """Initialize an empty toolset with a logger for error reporting."""
         self._tools: dict[str, Tool] = {}
         self.logger = logger
         self.last_timings: dict[str, int] = {}
@@ -24,27 +37,29 @@ class ToolBox:
         return tool_name in self._tools
 
     def add(self, tool: Tool) -> None:
-        """Add a tool to the toolbox."""
+        """Add a tool to the toolset."""
         self._tools[tool.name] = tool
 
     def get(self, tool_name: str) -> Tool | None:
-        """Get a tool from the toolbox by name."""
+        """Get a tool from the toolset by name."""
         return self._tools.get(tool_name)
 
     def remove(self, tool_name: str) -> None:
-        """Remove a tool from the toolbox by name."""
+        """Remove a tool from the toolset by name."""
         self._tools.pop(tool_name, None)
 
-    def short_description(self) -> str:
-        """Short description of tools in toolbox for LLM awareness."""
+    def system_prompt(self) -> str:
+        """The tool roster plus each tool's own prompt contribution, for the system prompt."""
         if not self._tools:
             return "No tools available"
 
-        descriptions = []
+        roster = ["You have tools:"]
         for i, tool in enumerate(self._tools.values(), 1):
-            descriptions.append(f"{i}. {tool.one_line} ({tool.name})")
+            roster.append(f"{i}. {tool.one_line} ({tool.name})")
 
-        return "\n".join(descriptions)
+        sections = ["\n".join(roster)]
+        sections.extend(c for tool in self._tools.values() if (c := tool.system_prompt()))
+        return "\n\n".join(sections)
 
     def format_for_api(self) -> list[ToolParam]:
         """Convert tools to Claude API format."""
@@ -66,10 +81,26 @@ class ToolBox:
             )
 
         tool = self._tools[tool_name]
+
+        try:
+            kwargs = tool.Input.model_validate(tool_input).model_dump()
+        except ValidationError as exc:
+            # Invalid input: skip execute and hand a parsed, per-field message back to the
+            # model so it can fix the arguments. Other parallel calls still run.
+            content = _format_validation_error(tool_name, exc)
+            self.logger.warning("Tool input invalid", labels={"toolName": tool_name, "error": content})
+            self.last_timings[tool_call.id] = 0
+            return ToolResultBlockParam(
+                type="tool_result",
+                tool_use_id=tool_call.id,
+                content=content,
+                is_error=True,
+            )
+
         start = time.monotonic()
 
         try:
-            result = await tool.execute(**tool_input)
+            result = await tool.execute(**kwargs)
         except Exception as exc:
             # A tool raising must not kill the whole agent run. Hand the error back to
             # the model as a failed tool_result so it can recover or report it.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "baski"
-version = "0.6.0"
+version = "0.6.1"
 description = "Shared foundation library: primitives, patterns, FastAPI server, GCP integrations, Telegram framework."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -242,7 +242,7 @@ wheels = [
 
 [[package]]
 name = "baski"
-version = "0.6.0"
+version = "0.6.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },


### PR DESCRIPTION
## Summary

Reworks `baski.agents` into a dependency-injected, validated, two-mode agent loop. Bumps to `0.6.1`.

### Dependency injection
The `Agent` constructs nothing. The caller assembles the `ToolSet`, `MessageHistory`, and `ShortTermMemory` and passes them via `AgentConfig`, plus an `on_event` listener via the constructor. The system prompt is **composed** (`config.system_prompt` + the toolset's prompt + generic loop guidance), not overridden.

### Renames
- `ToolBox` → `ToolSet`
- `KnowledgeTool` → `ShortTermMemory` (tool name `store_knowledge` → `store_memory`)

### Per-tool system prompts
`Tool.system_prompt()` lets each tool contribute its own block; `ToolSet.system_prompt()` aggregates the roster + contributions. The knowledge/context instructions moved out of `Agent` into the owning tools.

### Input validation (Pydantic)
Each tool declares a nested `Input(BaseModel)`; `input_schema` is **derived** from it and a tool with no `Input` fails at class-definition time. `ToolSet` validates every call against `Input` before `execute` and returns a parsed, per-field LLM-friendly error as the `tool_result` on failure — valid calls in the same parallel batch still run. Validated/coerced kwargs flow into `execute`.

### Two-mode loop (pinned context)
One param-free `execute()`:
- **Task mode** — the caller pins the framed request with `add_pinned_text`/`add_pinned`. Pinned messages live on the `Agent`, render first every turn, and are never in `message_history.turns`, so `truncate`/`delete_messages` cannot reach them.
- **Chat mode** — the caller adds the message to the injected `MessageHistory` (which may be pre-loaded to continue a prior conversation) and runs `execute()`.

`on_event` moved to the constructor; the trace/log label is derived from the newest user text.

## Test plan
- `make test` (ruff + 40 pytest) green.
- Throwaway scripts verified: derived schema; valid+invalid parallel mix (only invalid errors, with parsed per-field messages); `str`→`list` / `str`→`int` coercion; `TypeError` for a tool missing `Input`; task-mode pin renders first and survives `delete_turns`; chat-mode message in history with the label tracking the newest turn.
- Downstream consumer (nisse) updated and green (ruff + mypy + 12 pytest).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
