### PR TITLE
Tool.user_message() injection hook + synchronous Cloud Tasks webhook worker (0.6.2)

### DIFF
--- a/baski/agents/CLAUDE.md
+++ b/baski/agents/CLAUDE.md
@@ -7,7 +7,7 @@ Ported from clarity-auto-care; the generic core lives here so other projects (e.
 
 - `Agent` (`agent.py`): the agentic loop. Constructs nothing — the caller passes collaborators via `AgentConfig` plus an `on_event` listener.
 - `ToolSet` (`toolset.py`): tool registry + parallel executor; validates each call against the tool's `Input` model; `system_prompt()` aggregates the roster + per-tool contributions.
-- `Tool` (`tool.py`): abstract base. A tool declares `name`/`one_line`/`description`, a nested `Input(BaseModel)`, and `async execute(**kwargs) -> str`; optional `system_prompt()`.
+- `Tool` (`tool.py`): abstract base. A tool declares `name`/`one_line`/`description`, a nested `Input(BaseModel)`, and `async execute(**kwargs) -> str`; optional `system_prompt()` (static guidance into the system prompt) and `user_message()` (a per-turn user block injected at the top — short-term facts, a memory index, a skill body; default None). The Agent collects `user_message()` from every tool, so injection needs no dedicated config field.
 - `MessageHistory` (`message_history.py`): transcript with context-window truncation.
 - `TraceCollector` (`trace.py`): turn-by-turn traces → GCS + Mongo `traces`.
 - `AgentExecuteResult` (`execute_result.py`): pydantic result (trace id, tokens, counts, cost).
@@ -15,7 +15,7 @@ Ported from clarity-auto-care; the generic core lives here so other projects (e.
 ## Built-in Tools (`tools/`)
 
 The caller wires these into the `ToolSet` (not auto-injected):
-- `ShortTermMemory` (`store_memory`): per-run fact scratchpad; also passed as `AgentConfig.short_term_memory`.
+- `ShortTermMemory` (`store_memory`): per-run fact scratchpad; injects its facts via `user_message()`.
 - `DeleteMessagesTool` (`delete_messages`): drop turns by id; built with the shared `MessageHistory`.
 - `GoogleSearchTool`, `YelpSearchTool`, `GooglePlayTool`, `AppleAppStoreTool` (SerpApi), `WebBrowseTool` (Playwright).
 

--- a/baski/agents/agent.py
+++ b/baski/agents/agent.py
@@ -17,7 +17,6 @@ from .events import Message as MessageEvent
 from .execute_result import AgentExecuteResult
 from .message_history import MessageHistory
 from .pricing import ExecutionStats
-from .tools import ShortTermMemory
 from .toolset import ToolSet
 from .trace import TraceCollector, TraceCollectorConfig
 
@@ -54,17 +53,15 @@ class TurnResult(NamedTuple):
 class AgentConfig(NamedTuple):
     """Configuration parameters for Agent initialization.
 
-    The caller assembles the collaborators (`toolset`, `message_history`,
-    `short_term_memory`) and passes them in — the Agent constructs nothing. The
-    `short_term_memory` instance must also be present in the `toolset` so the model
-    can call it; the separate field gives the Agent typed access for per-turn
-    knowledge injection.
+    The caller assembles the collaborators (`toolset`, `message_history`) and passes
+    them in — the Agent constructs nothing. Per-turn knowledge injection (short-term
+    facts, memory indexes, skill bodies) flows through each tool's `user_message()`,
+    collected by the toolset — no tool needs a dedicated config field.
     """
 
     logger: Logger
     toolset: ToolSet
     message_history: MessageHistory
-    short_term_memory: ShortTermMemory
     anthropic_client: AsyncAnthropic
     database: AsyncDatabase
     bucket_name: str
@@ -88,7 +85,6 @@ class Agent:
         self.anthropic_client = config.anthropic_client
         self.message_history = config.message_history
         self.toolset = config.toolset
-        self.short_term_memory = config.short_term_memory
         self.on_event = on_event
         # Not in message_history.turns, so truncate/delete_messages can't reach it.
         self._pinned: list[MessageParam] = []
@@ -173,8 +169,8 @@ class Agent:
         )
         return [
             *self._pinned,
+            *self.toolset.user_messages(),
             time_message,
-            self.short_term_memory.format_as_user_message(),
             *self.message_history.format_for_api(),
         ]
 

--- a/baski/agents/tool.py
+++ b/baski/agents/tool.py
@@ -3,7 +3,7 @@
 from abc import ABC, abstractmethod
 from typing import Any, ClassVar
 
-from anthropic.types import ToolParam
+from anthropic.types import MessageParam, ToolParam
 from pydantic import BaseModel
 
 
@@ -49,6 +49,17 @@ class Tool(ABC):
     def system_prompt(self) -> str:
         """Extra instructions this tool adds to the agent system prompt. None by default."""
         return ""
+
+    def user_message(self) -> MessageParam | None:
+        """A user-role block this tool injects at the top of every turn, or None.
+
+        The seam for always-present, per-turn context a tool owns — short-term memory's
+        fact list, a long-term memory index, a skill's loaded body. The Agent collects
+        these from every tool in the set; default None means the tool injects nothing.
+        Keep the content stable within a run (date-only timestamps) to preserve the
+        prompt cache.
+        """
+        return None
 
     @abstractmethod
     async def execute(self, **kwargs: object) -> str:

--- a/baski/agents/tools/short_term_memory.py
+++ b/baski/agents/tools/short_term_memory.py
@@ -100,8 +100,8 @@ Use aggressively - store first, synthesize later. More is better than perfect.""
         """Clear all stored knowledge."""
         self.knowledge.clear()
 
-    def format_as_user_message(self) -> MessageParam:
-        """Format all knowledge as user message for API."""
+    def user_message(self) -> MessageParam:
+        """Format all knowledge as the per-turn user block injected at the top of the prompt."""
         parts = [f"IMPORTANT: Use {self.name} tool immediately after learning ANY new information to prevent loss.", ""]
 
         if not self.knowledge:

--- a/baski/agents/toolset.py
+++ b/baski/agents/toolset.py
@@ -3,7 +3,7 @@
 import asyncio
 import time
 
-from anthropic.types import ToolParam, ToolResultBlockParam, ToolUseBlock
+from anthropic.types import MessageParam, ToolParam, ToolResultBlockParam, ToolUseBlock
 from pydantic import ValidationError
 
 from baski.server import Logger
@@ -60,6 +60,10 @@ class ToolSet:
         sections = ["\n".join(roster)]
         sections.extend(c for tool in self._tools.values() if (c := tool.system_prompt()))
         return "\n\n".join(sections)
+
+    def user_messages(self) -> list[MessageParam]:
+        """Per-turn user blocks every tool injects at the top of the prompt (skip Nones)."""
+        return [m for tool in self._tools.values() if (m := tool.user_message()) is not None]
 
     def format_for_api(self) -> list[ToolParam]:
         """Convert tools to Claude API format."""

--- a/baski/clients/scheduler.py
+++ b/baski/clients/scheduler.py
@@ -62,10 +62,14 @@ class CloudTasksScheduler:
         endpoint: str,
         task_name: str,
         payload: bytes,
+        dispatch_deadline: datetime.timedelta,
         headers: dict[str, str] | None = None,
         schedule_time: datetime.datetime | None = None,
     ) -> bool:
-        """Create an HTTP task POSTing payload to endpoint; False if task_name already exists."""
+        """Create an HTTP task POSTing payload to endpoint; False if task_name already exists.
+
+        `dispatch_deadline` bounds how long Cloud Tasks waits for the worker (HTTP range 15s-30min).
+        """
         parent = self._client.queue_path(self._project_id, self._location, self._queue)
         task = tasks_v2.Task(
             name=f"{parent}/tasks/{task_name}",
@@ -76,6 +80,7 @@ class CloudTasksScheduler:
                 body=payload,
                 oidc_token=tasks_v2.OidcToken(service_account_email=self._invoker_sa_email),
             ),
+            dispatch_deadline=dispatch_deadline,
         )
         if schedule_time is not None:
             ts = timestamp_pb2.Timestamp()

--- a/baski/infra/run.py
+++ b/baski/infra/run.py
@@ -42,6 +42,7 @@ class CloudRunServiceConfig:
     ingress: str = "INGRESS_TRAFFIC_INTERNAL_LOAD_BALANCER"
     min_instances: int = 0
     max_instances: int = 8
+    timeout: str | None = None  # request timeout, e.g. "1800s"; None → Cloud Run default (300s)
 
 
 def create_cloud_run_env(name: str, value: str) -> gcp.cloudrunv2.ServiceTemplateContainerEnvArgs:
@@ -140,6 +141,7 @@ def create_cloud_run_with_monitoring(config: CloudRunServiceConfig) -> CloudRunS
             ),
             service_account=config.service_account_email,
             containers=[container_args],
+            timeout=config.timeout,
         ),
     )
     iam_member = None

--- a/baski/telegram/server.py
+++ b/baski/telegram/server.py
@@ -6,6 +6,7 @@ import asyncio
 import json
 from collections.abc import AsyncIterator, Iterable
 from contextlib import asynccontextmanager
+from datetime import timedelta
 from functools import cached_property
 from http import HTTPStatus
 from typing import Any
@@ -28,15 +29,18 @@ from ..server.async_server import AsyncServer
 __all__ = ["TelegramServer"]
 
 _WORKER_PATH = "/tasks/update"
+# The worker runs the whole agent turn synchronously; give Cloud Tasks the HTTP-target max so it
+# doesn't cancel a slow turn. Cloud Run's request timeout must be set at least this high.
+_WORKER_DEADLINE = timedelta(minutes=30)
 
 
 class TelegramServer(AsyncServer):
     """aiogram v3 server with two execution modes.
 
     - polling (default, local) — `dp.start_polling(bot)`.
-    - webhook (`--cloud`) — FastAPI + hypercorn, same stack as `FastAPIServer`. POSTs to the
-      webhook path are deserialized into `aiogram.types.Update` and dispatched via
-      `dp.feed_webhook_update`. Webhook registration runs on FastAPI startup.
+    - webhook (`--cloud`) — FastAPI + hypercorn, same stack as `FastAPIServer`. The webhook
+      enqueues each update to Cloud Tasks; the `/tasks/update` worker deserializes it into an
+      `aiogram.types.Update` and processes it fully via `dp.feed_update`. Registration runs on startup.
 
     Subclasses must implement `routers()`. Override `outer_middlewares` / `fsm_storage` /
     `add_webhook_routes` as needed.
@@ -136,13 +140,16 @@ class TelegramServer(AsyncServer):
                 endpoint=worker_url,
                 task_name=f"tg-update-{json.loads(raw)['update_id']}",
                 payload=raw,
+                dispatch_deadline=_WORKER_DEADLINE,
             )
             return Response(status_code=HTTPStatus.OK)
 
         @app.post(_WORKER_PATH)
         async def process_task(request: Request) -> Response:
+            # feed_update, not feed_webhook_update: the latter returns after 55s and finishes the
+            # handler on Cloud Run's throttled CPU, dropping the reply. Process fully, then answer.
             update = Update.model_validate(await request.json(), context={"bot": self.bot})
-            await self.dp.feed_webhook_update(self.bot, update)
+            await self.dp.feed_update(self.bot, update)
             return Response(status_code=HTTPStatus.OK)
 
         @app.get("/")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "baski"
-version = "0.6.1"
+version = "0.6.2"
 description = "Shared foundation library: primitives, patterns, FastAPI server, GCP integrations, Telegram framework."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -242,7 +242,7 @@ wheels = [
 
 [[package]]
 name = "baski"
-version = "0.6.1"
+version = "0.6.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },


### PR DESCRIPTION
## Summary

Two baski changes from the nisse memory + webhook work (patch bump 0.6.1 → 0.6.2).

### 1. Generalize per-turn injection via `Tool.user_message()`
`ShortTermMemory`'s fact injection was special-cased in `Agent._build_messages`. Promote it to a uniform `Tool.user_message()` hook, collected by `ToolSet.user_messages()` and inserted at the top of every turn. Short-term memory, long-term memory indexes, and future skills now inject through one interface; the redundant `AgentConfig.short_term_memory` field is dropped.

### 2. Process Telegram updates synchronously in the Cloud Tasks worker
The `/tasks/update` worker used `feed_webhook_update`, which returns after aiogram's internal 55s timeout and finishes the handler in the background. On Cloud Run (CPU throttled after the response returns) a long agent turn then runs starved of CPU and its reply is dropped — observed as a 7-min turn whose answer never reached the user.

- Worker now uses `feed_update`: the update is processed **fully** before answering 200.
- `CloudTasksScheduler.enqueue` takes a required `dispatch_deadline`; the webhook sets the 30-min HTTP-task max (verified ceiling per the Cloud Tasks proto: HTTP deadline ∈ [15s, 30min]).
- `CloudRunServiceConfig` gains a `timeout` field so the consuming service can set its request timeout at least as high (nisse sets `1800s`).

## Verification
`make lint` clean; `make test` 40 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
