### PR TITLE
feat(agents): expose current context size in AgentExecuteResult

### DIFF
--- a/baski/agents/agent.py
+++ b/baski/agents/agent.py
@@ -318,6 +318,7 @@ class Agent:
             turn_count=stats.turn_count,
             tool_call_count=stats.tool_calls,
             total_cost=stats.cost,
+            context_tokens=stats.last_input_tokens,
         )
 
         trace.finalize(stats, result)

--- a/baski/agents/execute_result.py
+++ b/baski/agents/execute_result.py
@@ -13,3 +13,4 @@ class AgentExecuteResult(BaseModel):
     turn_count: int = Field(..., description="Number of API calls (turns) in the agentic loop")
     tool_call_count: int = Field(..., description="Total number of tool calls across all turns")
     total_cost: float = Field(..., description="Total cost in USD for this execution")
+    context_tokens: int = Field(..., description="Input tokens on the last API call — the current context-window size")

--- a/baski/agents/pricing.py
+++ b/baski/agents/pricing.py
@@ -69,6 +69,7 @@ class ExecutionStats:
     model: str
     input_tokens: int = 0
     output_tokens: int = 0
+    last_input_tokens: int = 0  # input of the most recent API call — the current context-window size
     turn_count: int = 0
     tool_calls: int = 0
     cost: float = 0.0
@@ -77,6 +78,7 @@ class ExecutionStats:
         """Accumulate token usage and cost from a single API response."""
         self.input_tokens += usage.input_tokens
         self.output_tokens += usage.output_tokens
+        self.last_input_tokens = usage.input_tokens
         self.turn_count += 1
         self.cost += calculate_cost(self.model, usage.input_tokens, usage.output_tokens)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "baski"
-version = "0.6.3"
+version = "0.6.4"
 description = "Shared foundation library: primitives, patterns, FastAPI server, GCP integrations, Telegram framework."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -242,7 +242,7 @@ wheels = [
 
 [[package]]
 name = "baski"
-version = "0.6.3"
+version = "0.6.4"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },


### PR DESCRIPTION
## Why

A consumer (nisse) wants to show "how much context is in use right now" after a reply.
That number is the **last API call's input-token count** — the current context-window
occupancy. Surface it on `AgentExecuteResult`.

## Primary source, not History

`MessageHistory` already stores `_last_input_tokens`, but only because **it** needs it to
decide truncation. Reading the value back out of History to report context size would couple
the result to History's internals — a hack. The primary source is the Anthropic response's
`usage.input_tokens`, which the loop already collects.

- `ExecutionStats.last_input_tokens` — set each turn from `usage` (alongside the running sums).
- `AgentExecuteResult.context_tokens` — populated from it in `execute()`.

No change to `MessageHistory`.

## Verification

`make ci` green (lint + mypy 83 files + 40 tests). Exercised end-to-end from nisse against an
editable checkout: a reply reports `context_tokens` consistent with the model's reported usage.

version 0.6.3 → 0.6.4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
