### PR TITLE
fix(server): run the whole process on one event loop

### DIFF
--- a/baski/http/server.py
+++ b/baski/http/server.py
@@ -226,7 +226,7 @@ class FastAPIServer(AsyncServer):
             await self.check_health(request)
             return JSONResponse({"status": "healthy"})
 
-    def execute(self) -> int:
+    async def execute(self) -> int:
         """Launch hypercorn against the FastAPI app and run until shutdown."""
         bind = f"0.0.0.0:{self.args['port']}"
         config_opts: dict[str, Any] = {
@@ -241,5 +241,5 @@ class FastAPIServer(AsyncServer):
             config_opts["certfile"] = "cert.pem"
             config_opts["keyfile"] = "key.pem"
         config = HypercornConfig.from_mapping(**config_opts)
-        asyncio.run(serve(self.app, config))  # type: ignore[arg-type]
+        await serve(self.app, config)  # type: ignore[arg-type]
         return 0

--- a/baski/server/async_server.py
+++ b/baski/server/async_server.py
@@ -143,8 +143,8 @@ class AsyncServer:
         """Make the instance callable so it can be used as a CLI entry point."""
         return self.run()
 
-    def run(self) -> int:
-        """Top-level entry: log startup, execute, swallow KeyboardInterrupt."""
+    def run(self) -> int:  # noqa: PLR0915 — startup logging + single-loop lifecycle + error handling, inline by design
+        """Top-level entry: log startup, run execute() on the process's single loop, swallow KeyboardInterrupt."""
         try:
             if self.args["cloud"]:
                 logger.warning("Start %s", self.name)
@@ -154,8 +154,16 @@ class AsyncServer:
                 logger.info("Dry run of %s complete", self.name)
                 return 0
 
-            with self.loop_executor:
-                return self.execute()
+            # One event loop for the whole process, set current before execute() builds anything: every
+            # async client (gRPC, aiohttp, …) constructed inside it binds to this loop, so a future
+            # created on it is always awaited on it. run() owns the loop; subclasses just give async work.
+            loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(loop)
+            try:
+                with self.loop_executor:
+                    return loop.run_until_complete(self.execute())
+            finally:
+                loop.close()
         except KeyboardInterrupt:
             logger.info("Interrupted %s", self.name)
         except Exception as err:
@@ -163,6 +171,6 @@ class AsyncServer:
             raise
         return 1
 
-    def execute(self) -> int:
-        """Subclass hook: do the actual work and return an exit code."""
+    async def execute(self) -> int:
+        """Subclass hook: do the actual async work and return an exit code. Run by run() on the process loop."""
         raise NotImplementedError("Subclass must implement execute()")

--- a/baski/telegram/server.py
+++ b/baski/telegram/server.py
@@ -2,7 +2,6 @@
 
 import abc
 import argparse
-import asyncio
 import json
 from collections.abc import AsyncIterator, Iterable
 from contextlib import asynccontextmanager
@@ -96,21 +95,18 @@ class TelegramServer(AsyncServer):
         parser.add_argument("--webhook-url", default=str(get_env("WEBHOOK_URL", "")), help="Public webhook URL")
         parser.add_argument("--token", default=str(get_env("TELEGRAM_TOKEN", "")), help="Telegram bot token")
 
-    def execute(self) -> int:
+    async def execute(self) -> int:
         """Run the server in webhook or polling mode based on `--cloud`."""
         if self.args["cloud"]:
-            return self._run_webhook()
-        return self._run_polling()
+            return await self._run_webhook()
+        return await self._run_polling()
 
-    def _run_polling(self) -> int:
-        async def main() -> None:
-            await self.bot.delete_webhook(drop_pending_updates=False)
-            await self.dp.start_polling(self.bot)
-
-        asyncio.run(main())
+    async def _run_polling(self) -> int:
+        await self.bot.delete_webhook(drop_pending_updates=False)
+        await self.dp.start_polling(self.bot)
         return 0
 
-    def _run_webhook(self) -> int:  # noqa: PLR0915 — wires startup + webhook/worker/ping routes inline
+    async def _run_webhook(self) -> int:  # noqa: PLR0915 — wires startup + webhook/worker/ping routes inline
         webhook_url = self.args["webhook_url"]
         parsed = urlparse(webhook_url)
         path = parsed.path or "/webhook"
@@ -161,5 +157,5 @@ class TelegramServer(AsyncServer):
 
         bind = f"0.0.0.0:{self.args['port']}"
         config = HypercornConfig.from_mapping(bind=[bind], accesslog=None)
-        asyncio.run(serve(app, config))  # type: ignore[arg-type]
+        await serve(app, config)  # type: ignore[arg-type]
         return 0


### PR DESCRIPTION
## Problem

In webhook mode, a subclass builds async clients while mounting routes — e.g. nisse constructs its Cloud Tasks **gRPC** client inside `add_webhook_routes()`. gRPC binds to whatever event loop is current at construction time. But `execute()` then called `asyncio.run(serve(...))`, which spins up a **second, fresh** loop for request handling.

Result: `create_task`'s future lived on the construction-time loop, while the webhook handler awaited it on the serve loop → `RuntimeError: got Future attached to a different loop` → **500 on every webhook**.

## Fix

`AsyncServer.run()` now owns the loop end to end: it creates the loop, sets it current, and drives `execute()` via a single `run_until_complete`. `execute()` becomes a coroutine; subclasses just provide async work and never touch the loop.

Because route mounting now runs **inside** the already-running loop, any async client built there binds to that same loop (`get_running_loop()` returns it), and every future is awaited on the loop it was created on. No cross-loop attachment is possible.

## Scope

Contained to baski — only `TelegramServer` and `FastAPIServer` override `execute()`; both updated. Removed all three `asyncio.run` call sites in the server path (`telegram` polling + webhook, `http`). Dropped the now-unused `import asyncio` in `telegram/server.py`.

## Verification

- `make lint typecheck test` — clean (mypy 83 files, 40 tests).
- nisse (editable baski) dry-run boots; real polling boot comes up healthy — no errors, no "different loop", no deprecation warnings.
- Full webhook gRPC-on-loop path proves out only on prod (needs Cloud Tasks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
