### PR TITLE
feat(agents): MessageHistory as a Protocol + InMemoryMessageHistory

### DIFF
--- a/baski/agents/CLAUDE.md
+++ b/baski/agents/CLAUDE.md
@@ -8,7 +8,7 @@ Ported from clarity-auto-care; the generic core lives here so other projects (e.
 - `Agent` (`agent.py`): the agentic loop. Constructs nothing — the caller passes collaborators via `AgentConfig` plus an `on_event` listener.
 - `ToolSet` (`toolset.py`): tool registry + parallel executor; validates each call against the tool's `Input` model; `system_prompt()` aggregates the roster + per-tool contributions.
 - `Tool` (`tool.py`): abstract base. A tool declares `name`/`one_line`/`description`, a nested `Input(BaseModel)`, and `async execute(**kwargs) -> str`; optional `system_prompt()` (static guidance into the system prompt) and `user_message()` (a per-turn user block injected at the top — short-term facts, a memory index, a skill body; default None). The Agent collects `user_message()` from every tool, so injection needs no dedicated config field.
-- `MessageHistory` (`message_history.py`): transcript with context-window truncation.
+- `MessageHistory` (`message_history.py`): **Protocol** the Agent drives; `InMemoryMessageHistory` is the default volatile implementation (token-budget truncation). Durability = a separate implementation of the Protocol (e.g. nisse's Mongo-backed one), never a subclass of the in-memory one. `delete_turns` is `async` so a durable impl can persist the removal.
 - `TraceCollector` (`trace.py`): turn-by-turn traces → GCS + Mongo `traces`.
 - `AgentExecuteResult` (`execute_result.py`): pydantic result (trace id, tokens, counts, cost).
 

--- a/baski/agents/__init__.py
+++ b/baski/agents/__init__.py
@@ -14,7 +14,7 @@ from .events import (
     noop,
 )
 from .execute_result import AgentExecuteResult
-from .message_history import MessageHistory
+from .message_history import InMemoryMessageHistory, MessageHistory
 from .tool import Tool
 from .toolset import ToolSet
 
@@ -26,6 +26,7 @@ __all__ = [
     "AgentRefusalError",
     "Completed",
     "EventType",
+    "InMemoryMessageHistory",
     "Listener",
     "Message",
     "MessageHistory",

--- a/baski/agents/message_history.py
+++ b/baski/agents/message_history.py
@@ -1,7 +1,7 @@
-"""Conversation history management with context-window truncation."""
+"""Conversation history: the Protocol the Agent depends on, plus an in-memory implementation."""
 
 from dataclasses import dataclass, field
-from typing import Self
+from typing import Protocol, Self
 
 from anthropic.types import ContentBlock, MessageParam, TextBlockParam, ToolResultBlockParam, Usage
 
@@ -16,8 +16,62 @@ class Turn:
     messages: list[MessageParam] = field(default_factory=list)
 
 
-class MessageHistory:
-    """Ordered conversation history with automatic context-window truncation."""
+class MessageHistory(Protocol):
+    """The transcript interface the Agent drives — it owns no persistence of its own.
+
+    The Agent reads `turns`/`max_tokens`, appends through the context manager + `add_*`, formats
+    with `format_for_api`, and trims with `truncate`. `InMemoryMessageHistory` is the default,
+    volatile implementation. A caller that needs durability supplies its OWN implementation of this
+    Protocol (e.g. Mongo-backed) rather than subclassing the in-memory one and patching it — that is
+    what kept in-memory trims (`truncate`, `delete_turns`) from ever reaching the durable store.
+    """
+
+    turns: list[Turn]  # the committed turns, oldest first — the active transcript
+    max_tokens: int  # context-window budget the truncation policy aims at
+
+    def __len__(self) -> int:
+        """Number of committed turns."""
+        ...
+
+    def __enter__(self) -> Self:
+        """Open a new turn to collect the messages of one agentic round."""
+        ...
+
+    def __exit__(self, *args: object) -> None:
+        """Commit the open turn to the transcript if it has any messages."""
+        ...
+
+    def add_assistant(self, content_blocks: list[ContentBlock]) -> None:
+        """Append the assistant's message (text/tool_use/thinking blocks) to the open turn."""
+        ...
+
+    def add_tool_results(self, results: list[ToolResultBlockParam]) -> None:
+        """Append the tool_result blocks for this round to the open turn."""
+        ...
+
+    def add_user_text(self, text: str) -> None:
+        """Append a plain user-text message to the open turn."""
+        ...
+
+    def format_for_api(self) -> list[MessageParam]:
+        """Render the transcript as the message list for the Anthropic API."""
+        ...
+
+    def truncate(self, usage: Usage) -> None:
+        """Drop oldest turns when the latest input-token usage exceeds the budget."""
+        ...
+
+    async def delete_turns(self, turn_ids: list[int]) -> int:
+        """Remove whole turns by id; async so a durable implementation can persist the removal."""
+        ...
+
+
+class InMemoryMessageHistory(MessageHistory):
+    """Ordered conversation history with automatic context-window truncation.
+
+    Volatile — turns live only for the process. Correct as a pure in-memory transcript; durable
+    transcripts are separate implementations of `MessageHistory`, never subclasses of this one.
+    """
 
     def __init__(
         self,
@@ -56,7 +110,7 @@ class MessageHistory:
     def _turn(self) -> Turn:
         """Return the active turn, raising if used outside the context manager."""
         if self._current_turn is None:
-            raise RuntimeError("No active turn; use MessageHistory as a context manager first")
+            raise RuntimeError("No active turn; use the history as a context manager first")
         return self._current_turn
 
     def add_assistant(self, content_blocks: list[ContentBlock]) -> None:
@@ -112,7 +166,7 @@ class MessageHistory:
 
         return result
 
-    def delete_turns(self, turn_ids: list[int]) -> int:
+    async def delete_turns(self, turn_ids: list[int]) -> int:
         """Remove entire turns by ID."""
         ids_to_remove = set(turn_ids)
         original = len(self.turns)

--- a/baski/agents/tools/delete_messages.py
+++ b/baski/agents/tools/delete_messages.py
@@ -28,7 +28,7 @@ Tool result turns are the largest — prioritize deleting those."""
 
     async def execute(self, turn_ids: list[int]) -> str:  # type: ignore[override]
         """Delete specified turns and return removal count."""
-        removed = self.message_history.delete_turns(turn_ids)
+        removed = await self.message_history.delete_turns(turn_ids)
         return f"Deleted {removed} message(s). Remaining: {len(self.message_history)} messages."
 
     def system_prompt(self) -> str:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "baski"
-version = "0.6.4"
+version = "0.7.0"
 description = "Shared foundation library: primitives, patterns, FastAPI server, GCP integrations, Telegram framework."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -251,7 +251,7 @@ wheels = [
 
 [[package]]
 name = "baski"
-version = "0.6.4"
+version = "0.7.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },


### PR DESCRIPTION
## What

Turn `MessageHistory` into an interface so a durable transcript can be a first-class implementation, not a subclass-and-patch of the in-memory one.

- `MessageHistory` → `typing.Protocol` (the surface the `Agent` drives: `turns`, `max_tokens`, context manager, `add_*`, `format_for_api`, `truncate`, async `delete_turns`).
- The old concrete class → `InMemoryMessageHistory` (logic unchanged — correct as a volatile transcript).
- `delete_turns` is now `async` so a durable implementation can persist the removal; `DeleteMessagesTool` awaits it.
- Export both from `baski.agents`; `agents/CLAUDE.md` updated.

## Why

A durable transcript that subclassed the in-memory class had two layers of state that drifted: in-memory trims (`truncate`, `delete_messages`) never reached the durable store, so dropped turns resurrected on reload. With an interface, the durable implementation (nisse's Mongo-backed `MongoMessageHistory`) owns its persistence semantics directly.

## Blast radius

Only `Agent` (type hint), `DeleteMessagesTool`, the `__init__` export, and nisse use this. `clarity-auto-care` has its own ported copy and is unaffected.

## Tests

`uv run pytest` → 40 passed. ruff + mypy clean.

> ⚠️ Merge this **before** the nisse PR (`fix/durable-history-trimming`) — nisse's CI resolves baski from `git@main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
