### PR TITLE
refactor(agents): async, per-turn Tool.system_prompt()

### DIFF
--- a/baski/agents/agent.py
+++ b/baski/agents/agent.py
@@ -93,10 +93,9 @@ class Agent:
         # Not in message_history.turns, so truncate/delete_messages can't reach it.
         self._pinned: list[MessageParam] = []
 
-        system = f"{config.system_prompt}\n\n{self.toolset.system_prompt()}\n\n{AGENT_LOOP_GUIDANCE}"
+        self._system_prompt = config.system_prompt
 
         self.params: dict[str, object] = {
-            "system": system,
             "model": config.model,
             "tools": self.toolset.format_for_api(),
             "tool_choice": {"type": "auto", "disable_parallel_tool_use": False},
@@ -111,6 +110,10 @@ class Agent:
     def add_pinned_text(self, text: str) -> None:
         """Pin a plain user-text message (e.g. a one-shot task framed for the model)."""
         self.add_pinned(MessageParam(role="user", content=[TextBlockParam(type="text", text=text)]))
+
+    async def _system(self) -> str:
+        """Assemble the system prompt fresh — tool contributions (e.g. owner preferences) can change per turn."""
+        return f"{self._system_prompt}\n\n{await self.toolset.system_prompt()}\n\n{AGENT_LOOP_GUIDANCE}"
 
     async def _stream_message(self, messages: list[MessageParam]) -> Message:
         """Stream one response, emitting each text delta to the listener; return the assembled message."""
@@ -240,6 +243,7 @@ class Agent:
         trace.start_turn(messages)
 
         start = time.monotonic()
+        self.params["system"] = await self._system()  # reassembled each turn; tool guidance can be live
         message = await self._call_api(messages)
         api_duration_ms = int((time.monotonic() - start) * 1000)
 
@@ -291,7 +295,7 @@ class Agent:
             config=TraceCollectorConfig(
                 user_request=label,
                 model=str(self.params["model"]),
-                system_prompt=str(self.params["system"]),
+                system_prompt=await self._system(),
                 bucket_name=self.bucket_name,
                 database=self.database,
                 logger=self.logger,

--- a/baski/agents/tool.py
+++ b/baski/agents/tool.py
@@ -46,8 +46,13 @@ class Tool(ABC):
             input_schema=self.input_schema,
         )
 
-    def system_prompt(self) -> str:
-        """Extra instructions this tool adds to the agent system prompt. None by default."""
+    async def system_prompt(self) -> str:
+        """Extra instructions this tool adds to the agent system prompt, or "" for none.
+
+        Async and re-read every turn (symmetric with `user_message`), so a tool whose guidance
+        depends on live state — e.g. owner preferences loaded from a store — can return current
+        content each turn rather than a value frozen at build time.
+        """
         return ""
 
     async def user_message(self) -> MessageParam | None:

--- a/baski/agents/tools/delete_messages.py
+++ b/baski/agents/tools/delete_messages.py
@@ -31,7 +31,7 @@ Tool result turns are the largest — prioritize deleting those."""
         removed = await self.message_history.delete_turns(turn_ids)
         return f"Deleted {removed} message(s). Remaining: {len(self.message_history)} messages."
 
-    def system_prompt(self) -> str:
+    async def system_prompt(self) -> str:
         """Instructions telling the agent to free context after storing knowledge."""
         return (
             "CONTEXT MANAGEMENT: After storing knowledge, delete the source turns with "

--- a/baski/agents/tools/short_term_memory.py
+++ b/baski/agents/tools/short_term_memory.py
@@ -115,7 +115,7 @@ Use aggressively - store first, synthesize later. More is better than perfect.""
             content=[TextBlockParam(type="text", text="\n".join(parts))],
         )
 
-    def system_prompt(self) -> str:
+    async def system_prompt(self) -> str:
         """Instructions telling the agent to preserve facts proactively."""
         return (
             f"IMPORTANT: Use {self.name} proactively to preserve important information.\n"

--- a/baski/agents/toolset.py
+++ b/baski/agents/toolset.py
@@ -48,8 +48,12 @@ class ToolSet:
         """Remove a tool from the toolset by name."""
         self._tools.pop(tool_name, None)
 
-    def system_prompt(self) -> str:
-        """The tool roster plus each tool's own prompt contribution, for the system prompt."""
+    async def system_prompt(self) -> str:
+        """The tool roster plus each tool's own prompt contribution, for the system prompt.
+
+        Async and aggregated every turn (like `user_messages`), so tools whose guidance is live
+        (e.g. owner preferences from a store) contribute fresh content each turn.
+        """
         if not self._tools:
             return "No tools available"
 
@@ -58,7 +62,7 @@ class ToolSet:
             roster.append(f"{i}. {tool.one_line} ({tool.name})")
 
         sections = ["\n".join(roster)]
-        sections.extend(c for tool in self._tools.values() if (c := tool.system_prompt()))
+        sections.extend([c for tool in self._tools.values() if (c := await tool.system_prompt())])
         return "\n\n".join(sections)
 
     async def user_messages(self) -> list[MessageParam]:


### PR DESCRIPTION
## What
Make `Tool.system_prompt()` and `ToolSet.system_prompt()` **async**, and assemble the agent's system prompt **every turn** instead of once at `__init__`.

## Why
`Tool.system_prompt()` was sync and baked into the system at construction, while its sibling `Tool.user_message()` is async and re-read each turn. That asymmetry made the system prompt effectively frozen — a tool whose guidance depends on live state (the next use case: owner-preference text loaded from a store, editable mid-conversation) couldn't contribute fresh content without an external patch on the already-built system. Fixing the asymmetry is the clean shape; a `set_system_extra`-style mutator would be a crutch.

## Changes
- `Tool.system_prompt()` → `async def`, default `""`.
- `ToolSet.system_prompt()` → `async def`, aggregates with `await` (same loop shape as `user_messages()`).
- `Agent`: drop the system from `__init__` params; add `_system()` and set `params["system"]` per turn in `_run_turn` (and feed the trace record from it). No prompt caching → re-assembling per turn is free.
- Built-in impls `short_term_memory`, `delete_messages` gain `async`.

## Blast radius
Only two call sites ever invoked it (the aggregator + the agent). Downstream consumers (nisse) update their `system_prompt()` impls to `async` in their own PR.

lint + mypy + tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
