### PR TITLE
feat(agents): prompt caching + cache-aware token accounting (0.8.0)

### DIFF
--- a/baski/agents/CLAUDE.md
+++ b/baski/agents/CLAUDE.md
@@ -29,4 +29,6 @@ Project-specific tools stay in the consuming project, NOT here. Canonical assemb
 
 - Tracing is mandatory: every `execute()` requires a Mongo `database` and a GCS `bucket_name`.
 - Extended thinking is `adaptive`; parallel tool use enabled; `max_tokens=128_000`.
+- **Prompt caching**: cache breakpoints set in `agent.py` (tools, system) and `format_for_api` (history, via `mark_cached`). Invariant when adding anything to the prompt — volatile/per-turn content (time, context footer, `user_message()` injections) must go AFTER the last breakpoint; keep it in `_build_messages`' trailing section, never inside `format_for_api`. `mark_cached` must stay copy-safe (mutating a stored turn would persist `cache_control`).
+- Size context only via `pricing.effective_input_tokens` — caching hides cached tokens from `usage.input_tokens`, so a `truncate` reading it raw never trims.
 - The clarity FastAPI trace-browser router was NOT ported — deployment-specific. Add a thin router in the consuming project if a trace UI is needed.

--- a/baski/agents/agent.py
+++ b/baski/agents/agent.py
@@ -15,7 +15,7 @@ from baski.server import Logger
 from .events import Completed, Listener, TextDelta, Thinking, ToolFinished, ToolStarted, TurnStarted, noop
 from .events import Message as MessageEvent
 from .execute_result import AgentExecuteResult
-from .message_history import MessageHistory
+from .message_history import EPHEMERAL_CACHE, MessageHistory
 from .pricing import ExecutionStats
 from .toolset import ToolSet
 from .trace import TraceCollector, TraceCollectorConfig
@@ -95,9 +95,15 @@ class Agent:
 
         self._system_prompt = config.system_prompt
 
+        # Cache tools and system on separate breakpoints, so editing the system (e.g. core memory)
+        # doesn't evict the stabler tool-schema cache. (System breakpoint set per-turn in _run_turn.)
+        tools = self.toolset.format_for_api()
+        if tools:
+            tools[-1]["cache_control"] = EPHEMERAL_CACHE
+
         self.params: dict[str, object] = {
             "model": config.model,
-            "tools": self.toolset.format_for_api(),
+            "tools": tools,
             "tool_choice": {"type": "auto", "disable_parallel_tool_use": False},
             "thinking": {"type": "adaptive"},
             "max_tokens": 128_000,
@@ -180,11 +186,17 @@ class Agent:
             role="user",
             content=[TextBlockParam(type="text", text=f"Current time: {now.strftime('%A, %B %d, %Y %I:%M %p %Z')}")],
         )
+        # Stable prefix (pinned + history, cache breakpoint on the last turn) first; volatile blocks
+        # after it so they don't invalidate the cache: context footer, per-turn user_message()
+        # injections, then time (changes every minute).
+        history = self.message_history.format_for_api()
+        status = self.message_history.context_status()
         return [
             *self._pinned,
+            *history,
+            *([status] if status else []),
             *await self.toolset.user_messages(),
             time_message,
-            *self.message_history.format_for_api(),
         ]
 
     async def _execute_tools(
@@ -243,13 +255,14 @@ class Agent:
         trace.start_turn(messages)
 
         start = time.monotonic()
-        self.params["system"] = await self._system()  # reassembled each turn; tool guidance can be live
+        # Reassembled each turn — tool guidance can be live.
+        self.params["system"] = [TextBlockParam(type="text", text=await self._system(), cache_control=EPHEMERAL_CACHE)]
         message = await self._call_api(messages)
         api_duration_ms = int((time.monotonic() - start) * 1000)
 
         stats.collect(message.usage)
         await self.on_event(TurnStarted(turn=stats.turn_count))
-        if len(self.message_history) == 0 and message.usage.input_tokens > self.message_history.max_tokens // 2:
+        if len(self.message_history) == 0 and stats.last_input_tokens > self.message_history.max_tokens // 2:
             raise RuntimeError("Initial context is too large. Try to provide more LLM context.")
 
         self.message_history.truncate(message.usage)

--- a/baski/agents/message_history.py
+++ b/baski/agents/message_history.py
@@ -3,9 +3,60 @@
 from dataclasses import dataclass, field
 from typing import Protocol, Self
 
-from anthropic.types import ContentBlock, MessageParam, TextBlockParam, ToolResultBlockParam, Usage
+from anthropic.types import (
+    CacheControlEphemeralParam,
+    ContentBlock,
+    MessageParam,
+    TextBlockParam,
+    ToolResultBlockParam,
+    Usage,
+)
+from pydantic import BaseModel
 
 from baski.server.logger import Logger
+
+from .pricing import effective_input_tokens
+
+EPHEMERAL_CACHE = CacheControlEphemeralParam(type="ephemeral")
+
+
+_UNCACHEABLE_BLOCKS = {"thinking", "redacted_thinking"}  # these param types have no cache_control field
+
+
+def _block_type(block: object) -> str | None:
+    """The Anthropic `type` discriminator, whether the block is an SDK model or a plain dict."""
+    if isinstance(block, BaseModel):
+        return getattr(block, "type", None)
+    return block.get("type") if isinstance(block, dict) else None
+
+
+def mark_cached(message: MessageParam) -> MessageParam:
+    """Copy `message` with a prompt-cache breakpoint on its last cacheable content block.
+
+    Copy-safe (never mutates the input — a mutated stored turn would persist `cache_control`). Skips
+    trailing thinking blocks, which carry no `cache_control` field.
+    """
+    content = message["content"]
+    if not isinstance(content, list) or not content:
+        return message
+    blocks = list(content)
+    idx = next((i for i in reversed(range(len(blocks))) if _block_type(blocks[i]) not in _UNCACHEABLE_BLOCKS), -1)
+    if idx < 0:
+        return message
+    block = blocks[idx]
+    blocks[idx] = (block.model_dump() if isinstance(block, BaseModel) else dict(block)) | {
+        "cache_control": EPHEMERAL_CACHE
+    }
+    return MessageParam(role=message["role"], content=blocks)
+
+
+def context_status(last_input_tokens: int, max_tokens: int) -> MessageParam | None:
+    """The `[Context: N% used]` footer block (volatile — rides after the cache breakpoint), or None."""
+    if not last_input_tokens:
+        return None
+    pct = int(last_input_tokens / max_tokens * 100)
+    text = f"[Context: {pct}% used — {max_tokens - last_input_tokens:,} tokens remaining]"
+    return MessageParam(role="user", content=[TextBlockParam(type="text", text=text)])
 
 
 @dataclass
@@ -54,7 +105,11 @@ class MessageHistory(Protocol):
         ...
 
     def format_for_api(self) -> list[MessageParam]:
-        """Render the transcript as the message list for the Anthropic API."""
+        """Render the transcript as the message list for the Anthropic API (cache breakpoint on the last turn)."""
+        ...
+
+    def context_status(self) -> MessageParam | None:
+        """Volatile context-usage footer, appended AFTER the cache breakpoint (or None if no data yet)."""
         ...
 
     def truncate(self, usage: Usage) -> None:
@@ -141,30 +196,19 @@ class InMemoryMessageHistory(MessageHistory):
         )
 
     def format_for_api(self) -> list[MessageParam]:
-        """Return messages ready for API with [Turn N] markers on user messages."""
+        """Return messages ready for API with [Turn N] markers, cache breakpoint on the last turn."""
         result = []
         for turn in self.turns:
             result.append(MessageParam(role="user", content=[TextBlockParam(type="text", text=f"[Turn {turn.id}]")]))
             result.extend(turn.messages)
 
-        if self._last_input_tokens:
-            pct = int(self._last_input_tokens / self.max_tokens * 100)
-            result.append(
-                MessageParam(
-                    role="user",
-                    content=[
-                        TextBlockParam(
-                            type="text",
-                            text=(
-                                f"[Context: {pct}% used"
-                                f" — {self.max_tokens - self._last_input_tokens:,} tokens remaining]"
-                            ),
-                        )
-                    ],
-                )
-            )
-
+        if result:
+            result[-1] = mark_cached(result[-1])
         return result
+
+    def context_status(self) -> MessageParam | None:
+        """The context-usage footer, rendered by the shared helper from this history's counters."""
+        return context_status(self._last_input_tokens, self.max_tokens)
 
     async def delete_turns(self, turn_ids: list[int]) -> int:
         """Remove entire turns by ID."""
@@ -183,8 +227,9 @@ class InMemoryMessageHistory(MessageHistory):
 
     def truncate(self, usage: Usage) -> None:
         """Remove the oldest turns when threshold exceeded."""
-        self._last_input_tokens = usage.input_tokens
-        if usage.input_tokens < int(self.max_tokens * self.truncate_threshold) or not self.turns:
+        context_tokens = effective_input_tokens(usage)
+        self._last_input_tokens = context_tokens
+        if context_tokens < int(self.max_tokens * self.truncate_threshold) or not self.turns:
             return
 
         turns_to_remove = max(int(len(self.turns) * self.truncate_percentage), 1)
@@ -194,7 +239,7 @@ class InMemoryMessageHistory(MessageHistory):
         self.logger.info(
             "Truncated message history",
             labels={
-                "inputTokens": usage.input_tokens,
+                "inputTokens": context_tokens,
                 "maxTokens": self.max_tokens,
                 "threshold": self.max_tokens * self.truncate_threshold,
                 "turnsRemoved": initial_count - len(self.turns),

--- a/baski/agents/pricing.py
+++ b/baski/agents/pricing.py
@@ -31,24 +31,28 @@ MODEL_PRICING = {
 }
 
 
-def calculate_cost(model: str, input_tokens: int, output_tokens: int) -> float:
-    """Calculate cost in USD for a given model and token usage.
+# Cache multipliers vs base input price (5-minute ephemeral write, read).
+_CACHE_WRITE_MULTIPLIER = 1.25
+_CACHE_READ_MULTIPLIER = 0.10
 
-    Args:
-        model: Model name (e.g., "claude-sonnet-4-5")
-        input_tokens: Number of input tokens
-        output_tokens: Number of output tokens
 
-    Returns:
-        Cost in USD
+def effective_input_tokens(usage: Usage) -> int:
+    """Real context-window size: `input_tokens` (uncached only, under caching) plus both cache buckets."""
+    return usage.input_tokens + (usage.cache_read_input_tokens or 0) + (usage.cache_creation_input_tokens or 0)
 
-    """
+
+def calculate_cost(model: str, usage: Usage) -> float:
+    """Calculate cost in USD for one API response, pricing each cache bucket at its own rate."""
     pricing = MODEL_PRICING.get(model, MODEL_PRICING["claude-sonnet-4-5"])
 
-    input_cost = (input_tokens / 1_000_000) * pricing["input"]
-    output_cost = (output_tokens / 1_000_000) * pricing["output"]
+    input_cost = (usage.input_tokens / 1_000_000) * pricing["input"]
+    output_cost = (usage.output_tokens / 1_000_000) * pricing["output"]
+    cache_write_cost = (
+        ((usage.cache_creation_input_tokens or 0) / 1_000_000) * pricing["input"] * _CACHE_WRITE_MULTIPLIER
+    )
+    cache_read_cost = ((usage.cache_read_input_tokens or 0) / 1_000_000) * pricing["input"] * _CACHE_READ_MULTIPLIER
 
-    return input_cost + output_cost
+    return input_cost + output_cost + cache_write_cost + cache_read_cost
 
 
 class ExecutionLogFields(BaseModel):
@@ -75,12 +79,16 @@ class ExecutionStats:
     cost: float = 0.0
 
     def collect(self, usage: Usage) -> None:
-        """Accumulate token usage and cost from a single API response."""
+        """Accumulate token usage and cost from a single API response.
+
+        `last_input_tokens` is the real context-window size (incl. cached prefix); the cost prices
+        the cache read/write buckets at their own rates.
+        """
         self.input_tokens += usage.input_tokens
         self.output_tokens += usage.output_tokens
-        self.last_input_tokens = usage.input_tokens
+        self.last_input_tokens = effective_input_tokens(usage)
         self.turn_count += 1
-        self.cost += calculate_cost(self.model, usage.input_tokens, usage.output_tokens)
+        self.cost += calculate_cost(self.model, usage)
 
     def for_logs(self) -> ExecutionLogFields:
         """Build a structured log-fields model from current execution stats."""

--- a/baski/agents/trace.py
+++ b/baski/agents/trace.py
@@ -86,6 +86,8 @@ class TurnRecord(BaseModel):
     tool_results: list[ToolResultRecord] = []
     input_tokens: int = 0
     output_tokens: int = 0
+    cache_read_tokens: int = 0
+    cache_creation_tokens: int = 0
     duration_ms: int = 0
     stop_reason: str = ""
 
@@ -163,6 +165,8 @@ class TraceCollector:
         turn = self._turn
         turn.input_tokens = message.usage.input_tokens
         turn.output_tokens = message.usage.output_tokens
+        turn.cache_read_tokens = message.usage.cache_read_input_tokens or 0
+        turn.cache_creation_tokens = message.usage.cache_creation_input_tokens or 0
         turn.stop_reason = message.stop_reason or ""
 
         for block in message.content:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "baski"
-version = "0.7.0"
+version = "0.8.0"
 description = "Shared foundation library: primitives, patterns, FastAPI server, GCP integrations, Telegram framework."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -251,7 +251,7 @@ wheels = [
 
 [[package]]
 name = "baski"
-version = "0.7.0"
+version = "0.8.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },


### PR DESCRIPTION
## What

Enable Anthropic **prompt caching** in the agent loop, with cache-aware token accounting. Bumps `0.7.0 → 0.8.0`.

## Caching

- `cache_control` breakpoints on **three** stable points: the last tool schema, the system block, and the last settled turn of the history (`format_for_api` → `mark_cached`). Tools and system are **separate** breakpoints so editing the system (e.g. core memory) re-writes only the system block while the stabler tool schemas keep hitting.
- `_build_messages` puts the stable prefix first; volatile blocks — the `[Context: N% used]` footer (`context_status`), per-turn `user_message()` injections, and the current-time block — **trail** the last breakpoint so they never invalidate the cached prefix.
- `mark_cached` is copy-safe (never mutates a stored turn — a mutated block would persist `cache_control` to a durable transcript) and skips trailing `thinking` blocks, which carry no `cache_control` field.

## Cache-aware token accounting

Under caching `usage.input_tokens` counts only **uncached** tokens, which would silently break truncation (it would never trim) and undercount cost:

- `pricing.effective_input_tokens(usage)` sums the cache buckets back in — used by both `truncate` impls, the initial-context guard, and context-size.
- `calculate_cost(model, usage)` prices cache write (1.25×) and read (0.1×) separately.
- `trace` records per-turn `cache_read` / `cache_creation` tokens.

## Verification

Measured end-to-end via nisse's probe: a multi-turn reply showed turn 2 `cache_read` = turn 1's `cache_read + cache_write` — i.e. incremental history caching, with only the new turn written each step. `make lint` + `make test` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
