### PR TITLE
refactor(agents): clearer tool names (memory tiers + transcript pruning)

### DIFF
--- a/baski/agents/CLAUDE.md
+++ b/baski/agents/CLAUDE.md
@@ -15,8 +15,8 @@ Ported from clarity-auto-care; the generic core lives here so other projects (e.
 ## Built-in Tools (`tools/`)
 
 The caller wires these into the `ToolSet` (not auto-injected):
-- `ShortTermMemory` (`store_memory`): per-run fact scratchpad; injects its facts via `user_message()`.
-- `DeleteMessagesTool` (`delete_messages`): drop turns by id; built with the shared `MessageHistory`.
+- `ShortTermMemory` (`working_note`): WORKING MEMORY — per-reply fact scratchpad; injects its facts via `user_message()`.
+- `DeleteMessagesTool` (`prune_transcript`): drop turns by id; built with the shared `MessageHistory`.
 - `GoogleSearchTool`, `YelpSearchTool`, `GooglePlayTool`, `AppleAppStoreTool` (SerpApi), `WebBrowseTool` (Playwright).
 
 Project-specific tools stay in the consuming project, NOT here. Canonical assembly: nisse `app/assistant/assistant.py`.

--- a/baski/agents/agent.py
+++ b/baski/agents/agent.py
@@ -90,7 +90,7 @@ class Agent:
         self._await_trace = config.await_trace
         self._local_traces_dir = config.local_traces_dir
         self.on_event = on_event
-        # Not in message_history.turns, so truncate/delete_messages can't reach it.
+        # Not in message_history.turns, so truncate/prune_transcript can't reach it.
         self._pinned: list[MessageParam] = []
 
         self._system_prompt = config.system_prompt

--- a/baski/agents/tools/apple_app_store.py
+++ b/baski/agents/tools/apple_app_store.py
@@ -11,8 +11,8 @@ from ..tool import Tool
 class AppleAppStoreTool(Tool):
     """Tool for fetching Apple App Store data via SerpApi."""
 
-    name = "fetch_app_store_data"
-    one_line = "Fetch Apple App Store data"
+    name = "app_store_app"
+    one_line = "Fetch an app's Apple App Store listing"
     description = (
         "Fetch Apple App Store data by searching for company/app name. "
         "Returns app information including title, rating, developer, and description."

--- a/baski/agents/tools/delete_messages.py
+++ b/baski/agents/tools/delete_messages.py
@@ -9,13 +9,14 @@ from ..tool import Tool
 class DeleteMessagesTool(Tool):
     """Tool for agent to delete specific messages from conversation history."""
 
-    name = "delete_messages"
-    one_line = "Delete old messages to free context window"
-    description = """Delete turns from conversation history by [Turn N] IDs visible in messages.
+    name = "prune_transcript"
+    one_line = "Drop old conversation turns from the context window (does NOT touch any memory tier)"
+    description = """Prune turns from the conversation transcript by their [Turn N] IDs visible in messages.
+This only trims the live context window — it does NOT delete from memory (use a memory tool for that).
 
-Use after store_memory to remove turns whose content is already preserved.
-Old search results may contain outdated info — delete to avoid misleading context.
-Tool result turns are the largest — prioritize deleting those."""
+Use after working_note to drop turns whose content you've already preserved.
+Old search results may contain outdated info — prune to avoid misleading context.
+Tool-result turns are the largest — prioritize pruning those."""
 
     class Input(BaseModel):
         """Arguments for deleting conversation turns."""
@@ -34,7 +35,7 @@ Tool result turns are the largest — prioritize deleting those."""
     async def system_prompt(self) -> str:
         """Instructions telling the agent to free context after storing knowledge."""
         return (
-            "CONTEXT MANAGEMENT: After storing knowledge, delete the source turns with "
-            "delete_messages to free context space.\n"
-            "Workflow: search → store_memory → delete_messages for the turns you just stored."
+            "CONTEXT MANAGEMENT: after saving knowledge, prune the source turns with "
+            "prune_transcript to free context space.\n"
+            "Workflow: search → working_note → prune_transcript for the turns you just saved."
         )

--- a/baski/agents/tools/google_play.py
+++ b/baski/agents/tools/google_play.py
@@ -11,8 +11,8 @@ from ..tool import Tool
 class GooglePlayTool(Tool):
     """Tool for fetching Google Play developer apps via SerpApi."""
 
-    name = "fetch_google_play_data"
-    one_line = "Fetch Google Play developer apps"
+    name = "google_play_app"
+    one_line = "Fetch a Google Play developer's app listings by developer ID"
     description = (
         "Fetch Google Play developer apps and data using developer ID. Returns list of apps published by the developer."
     )

--- a/baski/agents/tools/short_term_memory.py
+++ b/baski/agents/tools/short_term_memory.py
@@ -24,31 +24,26 @@ def _coerce_facts(value: object) -> object:
 class ShortTermMemory(Tool):
     """Tool for agent to store knowledge gathered during conversation."""
 
-    name = "store_memory"
-    one_line = "Lightweight tool to preserve context (USE FREQUENTLY)"
-    description = """Store facts you discover during research to preserve them when conversation context gets truncated.
+    name = "working_note"
+    one_line = "WORKING MEMORY: jot a fact to this reply's scratchpad, cleared after the reply (USE FREQUENTLY)"
+    description = """WORKING MEMORY — a scratchpad for THIS reply only; it is cleared once the reply ends.
+Stash facts the moment you find them so they survive when the conversation context gets truncated mid-task.
 
-CRITICAL: This is a lightweight, fast operation. Use it extensively.
+NOT durable: to keep knowledge across future conversations, save it to long-term memory instead.
+
+CRITICAL: lightweight and fast — use it extensively.
 
 WHEN TO USE (frequently):
-- Immediately after extracting facts from any source
+- Immediately after extracting facts from any source or tool call
 - When you find conflicting information between sources
-- After every tool call that returns useful data
-- When noticing patterns, conflicts, or insights
-- After completing research on a specific topic (team, traction, market)
 - BEFORE you lose access to the information
 
 WHAT TO STORE:
-- Key facts, data points, and metrics from any source
-- Relationships and connections between entities
-- Observations, patterns, and discrepancies
-- Source attributions for critical claims
-- Context that might be needed later
+- Key facts, data points, metrics, relationships, observations, source attributions
+- Anything you'll need later this reply to synthesize the answer
 
 WHY THIS EXISTS:
-- Tool outputs disappear after a few turns
-- You need facts available to synthesize final reports later
-- Knowledge costs ~4k tokens vs 30k+ for keeping full sources
+- Tool outputs disappear after a few turns; a note costs ~4k tokens vs 30k+ for keeping full sources
 
 FACT FORMULATION FORMAT: [SOURCE] entity + fact + temporal context
 
@@ -84,7 +79,9 @@ Use aggressively - store first, synthesize later. More is better than perfect.""
         self.knowledge.extend(facts)
         stored = len(facts)
         total = len(self.knowledge)
-        return f"Stored {stored} fact(s). Total: {total}. Now delete source turns with Tool: delete_messages."
+        return (
+            f"Noted {stored} fact(s) to working memory. Total: {total}. Now prune source turns with prune_transcript."
+        )
 
     def dump(self) -> None:
         """Dump knowledge to markdown file (CLI only)."""
@@ -102,12 +99,16 @@ Use aggressively - store first, synthesize later. More is better than perfect.""
 
     async def user_message(self) -> MessageParam:
         """Format all knowledge as the per-turn user block injected at the top of the prompt."""
-        parts = [f"IMPORTANT: Use {self.name} tool immediately after learning ANY new information to prevent loss.", ""]
+        parts = [
+            f"WORKING MEMORY — this reply's scratchpad (cleared after the reply). Use {self.name} the "
+            "moment you learn anything, so it survives context truncation.",
+            "",
+        ]
 
         if not self.knowledge:
-            parts.append("No knowledge stored yet.")
+            parts.append("(empty)")
         else:
-            parts.append("Knowledge:")
+            parts.append("Notes:")
             parts.extend(f"- {k}" for k in self.knowledge)
 
         return MessageParam(
@@ -118,6 +119,7 @@ Use aggressively - store first, synthesize later. More is better than perfect.""
     async def system_prompt(self) -> str:
         """Instructions telling the agent to preserve facts proactively."""
         return (
-            f"IMPORTANT: Use {self.name} proactively to preserve important information.\n"
-            f"Store knowledge immediately after learning new facts to prevent loss during conversation."
+            f"WORKING MEMORY: use {self.name} proactively to preserve facts before context truncation; "
+            f"it is cleared after each reply. For durable knowledge that must survive across conversations, "
+            f"use your long-term memory tool instead."
         )


### PR DESCRIPTION
## What

Make agent tool names self-explanatory so the model can't confuse them.

The memory/context tools didn't encode their tier in the name, so `store_memory` (per-reply scratchpad) read the same as a long-term save and as core memory. Renames:

| Old | New | Why |
|-----|-----|-----|
| `store_memory` | `working_note` | WORKING MEMORY — per-reply scratchpad, cleared after the reply |
| `delete_messages` | `prune_transcript` | trims the context window; NOT a memory op (was mistaken for "forget") |
| `fetch_google_play_data` | `google_play_app` | "data" was contentless |
| `fetch_app_store_data` | `app_store_app` | same |

Descriptions reframed to name the tier (WORKING MEMORY) and state the lifetime (cleared after each reply). baski stays generic — no reference to any consumer's long-term tool names.

Driven by a 3-agent tool-name clarity audit: the `store_memory`/save collision and the `delete_messages`/forget collision were the top mis-pick risks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
