### PR TITLE
feat(agents): prune_transcript keep_last — bulk-clear all but the last N turns

### DIFF
--- a/baski/agents/tools/delete_messages.py
+++ b/baski/agents/tools/delete_messages.py
@@ -11,26 +11,34 @@ class DeleteMessagesTool(Tool):
 
     name = "prune_transcript"
     one_line = "Drop old conversation turns from the context window (does NOT touch any memory tier)"
-    description = """Prune turns from the conversation transcript by their [Turn N] IDs visible in messages.
+    description = """Prune turns from the conversation transcript to free context space.
 This only trims the live context window — it does NOT delete from memory (use a memory tool for that).
 
+Two ways to prune (combine if useful):
+- keep_last=N — keep only the last N turns, drop everything older. Use this to clear stale backlog
+  in one call (e.g. on a topic change) instead of listing dozens of ids.
+- turn_ids=[…] — drop specific turns by their [Turn N] ids visible in messages.
+
 Use after working_note to drop turns whose content you've already preserved.
-Old search results may contain outdated info — prune to avoid misleading context.
-Tool-result turns are the largest — prioritize pruning those."""
+Old search results may contain outdated info — prune to avoid misleading context."""
 
     class Input(BaseModel):
-        """Arguments for deleting conversation turns."""
+        """Arguments for pruning conversation turns — give keep_last, turn_ids, or both."""
 
-        turn_ids: list[int] = Field(description="Turn IDs to delete (visible as [Turn N] in messages)")
+        keep_last: int | None = Field(default=None, description="Keep only the last N turns; drop all older ones")
+        turn_ids: list[int] = Field(default_factory=list, description="Specific [Turn N] ids to drop")
 
     def __init__(self, message_history: MessageHistory) -> None:
         """Store reference to the shared message history."""
         self.message_history = message_history
 
-    async def execute(self, turn_ids: list[int]) -> str:  # type: ignore[override]
-        """Delete specified turns and return removal count."""
-        removed = await self.message_history.delete_turns(turn_ids)
-        return f"Deleted {removed} message(s). Remaining: {len(self.message_history)} messages."
+    async def execute(self, keep_last: int | None = None, turn_ids: list[int] | None = None) -> str:  # type: ignore[override]
+        """Drop the turns selected by keep_last and/or turn_ids; return the removal count."""
+        ids = set(turn_ids or [])
+        if keep_last is not None:
+            ids.update(turn.id for turn in self.message_history.turns[: -keep_last or None])
+        removed = await self.message_history.delete_turns(sorted(ids))
+        return f"Deleted {removed} turn(s). Remaining: {len(self.message_history)} turns."
 
     async def system_prompt(self) -> str:
         """Instructions telling the agent to free context after storing knowledge."""


### PR DESCRIPTION
## What
`prune_transcript` gains a `keep_last=N` argument: keep only the most recent N turns, drop everything older in **one** call. `turn_ids` still works (combine if useful).

## Why
The tool required enumerating explicit `[Turn N]` ids, so the model satisfices — it prunes the handful of turns it just worked with and leaves the long tail, which then dominates the context window. A single bulk lever removes that effort barrier.

## Notes
- Consumed by nisse (`MongoMessageHistory.delete_turns` makes the prune durable/soft-deleted). nisse PR depends on this landing in `main` for prod (prod pulls baski via `git+main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)