### PR TITLE
feat(playwright): Chromium + storage_state session load; drop as_async/as_task

### DIFF
--- a/baski/__init__.py
+++ b/baski/__init__.py
@@ -1,6 +1,6 @@
 """Baski — shared foundational library: HTTP/Telegram server templates, logger, and reusable primitives."""
 
-from .concurrent import as_async, as_task, map_async
+from .concurrent import map_async
 from .env import get_env, is_cloud, is_debug, is_test, port, project_id, token
 from .http import dependencies as dependencies
 from .on_exception import do_nothing, do_nothing_sync, on_exception
@@ -12,8 +12,6 @@ from .primitives.unique_id import unique_id
 
 __all__ = [
     "JSONDecodeError",
-    "as_async",
-    "as_task",
     "datetime",
     "dependencies",
     "do_nothing",

--- a/baski/agents/trace.py
+++ b/baski/agents/trace.py
@@ -15,7 +15,6 @@ from pydantic import BaseModel, ConfigDict, SkipValidation, field_serializer
 from pymongo.asynchronous.database import AsyncDatabase
 from pymongo.errors import PyMongoError
 
-from baski.concurrent import as_async, as_task
 from baski.primitives import datetime, json
 from baski.server import Logger
 
@@ -226,7 +225,7 @@ class TraceCollector:
         if result is not None:
             self._result = result
         self._error = error
-        task = as_task(self._persist(stats))
+        task = asyncio.create_task(self._persist(stats))
         self._persist_task = task
         _track(task)
 
@@ -258,7 +257,7 @@ class TraceCollector:
         """Persist the full record — to `local_traces_dir` when set (debug/probe), else GCS."""
         if self._local_traces_dir is not None:
             path = Path(self._local_traces_dir) / f"{self.id}.json"
-            await as_async(lambda: self._write_local(path))
+            await anyio.to_thread.run_sync(self._write_local, path)
         else:
             await self._upload_to_gcs()
 
@@ -277,7 +276,7 @@ class TraceCollector:
 
         upload_error: str | None = None
         try:
-            await as_async(_upload)
+            await anyio.to_thread.run_sync(_upload)
         except (GoogleAPIError, OSError) as e:
             upload_error = str(e)
 

--- a/baski/clients/playwright_client.py
+++ b/baski/clients/playwright_client.py
@@ -64,16 +64,27 @@ class PlaywrightClient:
         self._context: BrowserContext | None = None
 
     async def __aenter__(self) -> Self:
-        """Start Playwright and open a browser context, loading a saved session when present."""
+        """Start Playwright and open the default browser context, loading a saved session when present."""
         self._playwright = await async_playwright().start()
         self._browser = await self._playwright.chromium.launch(headless=self.headless)
-        context_args: dict[str, Any] = {"user_agent": _SAFARI_UA, "viewport": {"width": 1600, "height": 900}}
-        if self.storage_state and await AsyncPath(self.storage_state).exists():
-            context_args["storage_state"] = self.storage_state
-        self._context = await self._browser.new_context(**context_args)
-        self._context.set_default_timeout(self.timeout)
-        self._context.set_default_navigation_timeout(self.timeout)
+        self._context = await self.new_context(self.storage_state)
         return self
+
+    async def new_context(self, storage_state: str | None = None) -> BrowserContext:
+        """Open an isolated browser context with the shared config, loading a saved session when present.
+
+        Each context is a separate cookie/storage jar — callers that need per-tenant logins (e.g. one
+        per chat) open one context each. A missing ``storage_state`` file is ignored (logged-out).
+        """
+        if not self._browser:
+            raise RuntimeError("PlaywrightClient not initialized. Use async with context manager.")
+        context_args: dict[str, Any] = {"user_agent": _SAFARI_UA, "viewport": {"width": 1600, "height": 900}}
+        if storage_state and await AsyncPath(storage_state).exists():
+            context_args["storage_state"] = storage_state
+        context = await self._browser.new_context(**context_args)
+        context.set_default_timeout(self.timeout)
+        context.set_default_navigation_timeout(self.timeout)
+        return context
 
     async def __aexit__(
         self,

--- a/baski/clients/playwright_client.py
+++ b/baski/clients/playwright_client.py
@@ -89,6 +89,18 @@ class PlaywrightClient:
         if self._playwright:
             await self._playwright.stop()
 
+    async def new_page(self) -> Page:
+        """Open a blank page in the shared context for a caller to drive (interactive/headed use)."""
+        if not self._context:
+            raise RuntimeError("PlaywrightClient not initialized. Use async with context manager.")
+        return await self._context.new_page()
+
+    async def save_storage_state(self, path: str) -> None:
+        """Write the context's session (cookies + localStorage) to a Playwright storage-state file."""
+        if not self._context:
+            raise RuntimeError("PlaywrightClient not initialized. Use async with context manager.")
+        await self._context.storage_state(path=path)
+
     async def fetch_page_markdown(self, url: str) -> str:
         """Fetch webpage content and convert to markdown with retry logic.
 

--- a/baski/clients/playwright_client.py
+++ b/baski/clients/playwright_client.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Any, Self
 
 import trafilatura
+from anyio import Path as AsyncPath
 from bs4 import BeautifulSoup
 from httpx import HTTPStatusError
 from httpx import Request as HttpxRequest
@@ -37,23 +38,39 @@ class PlaywrightClient:
         async with PlaywrightClient(headless=True) as client:
             markdown = await client.fetch_page_markdown(url)
 
-    Note: Requires 'playwright install firefox' after pip install
+    Note: Requires 'playwright install chromium' after pip install
     """
 
-    def __init__(self, *, headless: bool = True, logger: Logger | None = None, timeout: int = 90000) -> None:
-        """Configure browser launch options; the browser is started in ``__aenter__``."""
+    def __init__(
+        self,
+        *,
+        headless: bool = True,
+        logger: Logger | None = None,
+        timeout: int = 90000,
+        storage_state: str | None = None,
+    ) -> None:
+        """Configure browser launch options; the browser is started in ``__aenter__``.
+
+        ``storage_state`` is a path to a Playwright storage-state file (cookies + localStorage). When
+        it points at an existing file, the context starts from that saved session, so pages behind a
+        login are reachable. A missing file is ignored — the context starts logged-out.
+        """
         self.headless = headless
         self.logger = logger
         self.timeout = timeout
+        self.storage_state = storage_state
         self._playwright: Playwright | None = None
         self._browser: Browser | None = None
         self._context: BrowserContext | None = None
 
     async def __aenter__(self) -> Self:
-        """Start Playwright and open a browser context."""
+        """Start Playwright and open a browser context, loading a saved session when present."""
         self._playwright = await async_playwright().start()
-        self._browser = await self._playwright.firefox.launch(headless=self.headless)
-        self._context = await self._browser.new_context(user_agent=_SAFARI_UA, viewport={"width": 1600, "height": 900})
+        self._browser = await self._playwright.chromium.launch(headless=self.headless)
+        context_args: dict[str, Any] = {"user_agent": _SAFARI_UA, "viewport": {"width": 1600, "height": 900}}
+        if self.storage_state and await AsyncPath(self.storage_state).exists():
+            context_args["storage_state"] = self.storage_state
+        self._context = await self._browser.new_context(**context_args)
         self._context.set_default_timeout(self.timeout)
         self._context.set_default_navigation_timeout(self.timeout)
         return self

--- a/baski/clients/playwright_client.py
+++ b/baski/clients/playwright_client.py
@@ -70,17 +70,22 @@ class PlaywrightClient:
         self._context = await self.new_context(self.storage_state)
         return self
 
-    async def new_context(self, storage_state: str | None = None) -> BrowserContext:
+    async def new_context(
+        self, storage_state: str | None = None, proxy: dict[str, str] | None = None
+    ) -> BrowserContext:
         """Open an isolated browser context with the shared config, loading a saved session when present.
 
         Each context is a separate cookie/storage jar — callers that need per-tenant logins (e.g. one
         per chat) open one context each. A missing ``storage_state`` file is ignored (logged-out).
+        ``proxy`` is Playwright's context proxy (``server``/``username``/``password``); None = direct.
         """
         if not self._browser:
             raise RuntimeError("PlaywrightClient not initialized. Use async with context manager.")
         context_args: dict[str, Any] = {"user_agent": _SAFARI_UA, "viewport": {"width": 1600, "height": 900}}
         if storage_state and await AsyncPath(storage_state).exists():
             context_args["storage_state"] = storage_state
+        if proxy:
+            context_args["proxy"] = proxy
         context = await self._browser.new_context(**context_args)
         context.set_default_timeout(self.timeout)
         context.set_default_navigation_timeout(self.timeout)

--- a/baski/concurrent.py
+++ b/baski/concurrent.py
@@ -7,7 +7,7 @@ from http import HTTPStatus
 
 from .server.config import AppConfig
 
-__all__ = ["as_async", "as_task", "map_async"]
+__all__ = ["map_async"]
 
 
 @functools.lru_cache
@@ -36,18 +36,3 @@ async def map_async(
 
         results.extend([p.result() for p in done if p.result() is not None])
     return results
-
-
-async def as_async(
-    f: typing.Callable,
-    *args: typing.Any,  # noqa: ANN401 — forwarded transparently to f
-    **kwargs: typing.Any,  # noqa: ANN401 — forwarded transparently to f
-) -> typing.Any:  # noqa: ANN401 — return type mirrors arbitrary callable f
-    """Run a blocking callable in the default executor and await the result."""
-    loop = asyncio.get_event_loop()
-    return await loop.run_in_executor(None, functools.partial(f, *args, **kwargs))
-
-
-def as_task(coro: typing.Coroutine) -> asyncio.Task:
-    """Schedule a coroutine on the running loop as a Task."""
-    return asyncio.get_event_loop().create_task(coro)

--- a/baski/telegram/middleware/unprocessed_middleware.py
+++ b/baski/telegram/middleware/unprocessed_middleware.py
@@ -1,16 +1,17 @@
 """Catch-all middleware for messages that no other handler processed."""
 
+import functools
 import io
 import pathlib
 import tempfile
 from collections.abc import Awaitable, Callable
 from typing import Any
 
+import anyio
 from aiogram import Bot, types
 from aiogram.exceptions import TelegramAPIError
 from google.cloud import storage
 
-from ...concurrent import as_async
 from ...pattern import retry
 from ...primitives import datetime
 from ..telemetry import UNKNOWN_MESSAGE_TYPE, MessageTelemetry
@@ -95,7 +96,9 @@ class UnprocessedMiddleware:
         with io.FileIO(name, "rb") as read_buffer:
             bucket_path = f"{message.chat.id}/{now:%Y-%m-%d}_{object_type}_{message.message_id}_{local_file_path.name}"
             blob = self.bucket.blob(bucket_path)
-            await as_async(blob.upload_from_file, file_obj=read_buffer, content_type=mime_type, num_retries=5)
+            await anyio.to_thread.run_sync(
+                functools.partial(blob.upload_from_file, file_obj=read_buffer, content_type=mime_type, num_retries=5)
+            )
 
     async def _download_media(
         self,

--- a/baski/telegram/storage/users.py
+++ b/baski/telegram/storage/users.py
@@ -7,7 +7,6 @@ from datetime import datetime
 from aiogram import types
 from google.cloud import firestore
 
-from ...concurrent import as_task
 from ...primitives.dataclass import from_doc
 
 __all__ = ["TelegramUser", "UsersStorage"]
@@ -80,5 +79,5 @@ class UsersStorage:
     def set(self, user: TelegramUser) -> None:
         """Schedule a merge-write of `user` in the background."""
         user_ref = self._db.document(str(user.id))
-        self._tasks.append(as_task(user_ref.set(asdict(user), merge=True)))
+        self._tasks.append(asyncio.create_task(user_ref.set(asdict(user), merge=True)))
         self._tasks = [t for t in self._tasks[:] if not t.done()]


### PR DESCRIPTION
## Why

Foundation for nisse's browser-**actions** feature (logged-in reads, then booking/checkout). The agent must reuse a session the owner established once — which Cloud Run's stateless browser can't hold on its own.

## What

**1. Chromium + `storage_state` (`PlaywrightClient`)**
- Engine swap Firefox → Chromium. Chromium is the only engine with a clean session-reuse story (Playwright `storage_state` round-trip, shared profile, CDP attach all work; Firefox has no supported path). baski's `PlaywrightClient` is consumed **only by nisse** (clarity has its own local copy), so the swap has no other blast radius.
- New `storage_state` constructor arg: when it points at an existing storage-state file (cookies + localStorage), the context starts from that saved session; a missing file is ignored (logged-out context). Existence checked via `anyio.Path`.

**2. Drop outdated `as_async` / `as_task`**
- `as_async` (a `loop.run_in_executor` wrapper) and `as_task` (`get_event_loop().create_task`) predate stdlib `asyncio.to_thread` / `asyncio.create_task`. Internal call sites now use `anyio.to_thread.run_sync` for blocking IO and `asyncio.create_task` for detached tasks. `map_async` stays (real bounded-concurrency logic).
- Verified only baski-internal code imported these — clarity and profit have their own `concurrent` module; nisse imports neither. No external consumer breaks.

## Consumer note

Downstream Dockerfiles must `playwright install chromium` (Firefox install no longer needed) — handled in the paired nisse PR.

## Verified

`ruff check` + `ruff format --check` + `mypy` (83 files) clean; `pytest tests/` 40 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
