### PR TITLE
feat(agents): capture thinking in traces (display=summarized)

### DIFF
--- a/baski/agents/agent.py
+++ b/baski/agents/agent.py
@@ -123,7 +123,9 @@ class Agent:
             "model": config.model,
             "tools": tools,
             "tool_choice": {"type": "auto", "disable_parallel_tool_use": False},
-            "thinking": {"type": "adaptive"},
+            # display=summarized so the thinking lands in the response (and our trace); the API
+            # otherwise returns it omitted (empty thinking, signature only) for Opus 4.7+.
+            "thinking": {"type": "adaptive", "display": "summarized"},
             "max_tokens": 128_000,
         } | params
 


### PR DESCRIPTION
## What

Pin `display: "summarized"` on the adaptive thinking param so the model's reasoning is captured in the response and the persisted agent trace.

## Why

Investigating "the assistant under-thinks" on real nisse traces, every turn stored `thinking: ['']` — an empty block. That is **not** proof the model didn't reason: on Opus 4.7+ adaptive thinking defaults to `display: "omitted"` (reasoning redacted, signature-only), so the trace is blind to thinking and the question is undiagnosable from the trace.

`display: "summarized"` makes the reasoning land in `block.thinking`, where `TraceCollector.record_response` already records it. No other code changes — `ThinkingBlock` is already handled in trace recording, logging, and event emit.

## Note

The SDK type docstring claims `summarized` is the default, but the live API returns omitted for Opus 4.8 (proven by the empty thinking in every trace), so the explicit pin is load-bearing, not a no-op.

## Verify

`make lint` / `make typecheck` (84 files) / `make test` (40) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
