### PR TITLE
fix(judge): trust tool-sourced recent data; depth must match the ask

### DIFF
--- a/baski/agents/judge.py
+++ b/baski/agents/judge.py
@@ -33,17 +33,26 @@ Mark finished=false ONLY if the answer:
 and it is absent,
 - stops at research or options without assembling the artifact that was requested,
 - presents specific figures or money-making "opportunities" with NO sourcing at all (a fabricated \
-arbitrage, a number from nowhere, a plausible-sounding niche with nothing behind it), or
+arbitrage, a number from nowhere, a plausible-sounding niche with nothing behind it),
+- answers an investigative / advisory / comparative ask ("какие способы…", "что мне сделать чтобы…", \
+"подумай…", "сравни…") with generic, obvious-tier options and NO concrete sourced specifics — when the \
+ask plainly warranted reading sources and comparing (depth must match the ask, below), or
 - withholds the requested work to ask permission or punt it back ("want me to…?") instead of just doing \
 it — but an answer that already delivers the work in full and merely ends with a trailing offer or \
 courtesy is DONE; do NOT redo just to strip that line.
 
-The conversation's `[tool]` lines show exactly which tools the assistant ran (live search, browse, etc.)
-with their arguments — but NOT their outputs. Treat a tool call as proof the work happened: a concrete or
-recent-sounding claim backed by a relevant `[tool]` call (or a source cited in the answer) is REAL — never
-call it fabricated, made-up, or "from the future" (the current date is given above; news up to it is real).
-Flag fabrication ONLY for a concrete factual/numeric claim with NO supporting tool call and NO cited source.
-You still CANNOT verify the actual values — grade completeness, not truth.
+The `[tool]` lines show every tool the assistant ran WITH its arguments, but NOT the outputs — so do not
+treat a tool call as automatic proof of enough work; match DEPTH to the ask. A casual remark, a closed fact
+lookup, or a current-events question is DONE by a direct answer or a search or two — demand no more. An open
+investigative / advisory / comparative ask warrants reading sources and comparing, so a generic answer with
+no concrete sourced specifics is incomplete — but one already carrying named sources, real figures, or a
+genuine comparison IS done; never redo for more depth or for style.
+
+You grade COMPLETENESS, not truth — you CANNOT verify the actual values. A concrete or recent claim backed
+by a relevant `[tool]` call or a source cited in the answer is grounded: NEVER call it fabricated, made-up,
+or "from the future." Your own training cutoff is NOT the current date (given above) — tool-sourced or cited
+data dated later than what you happen to know is REAL, not a hallucination and not a date error. Flag
+fabrication ONLY for a concrete factual/numeric claim with NO supporting tool call AND NO cited source.
 
 A substantively complete, grounded answer is DONE even if its wording, formatting, length, structure, or
 persona/voice are imperfect — do NOT redo for style. An honest "I can't do X without Y" is also DONE, NOT


### PR DESCRIPTION
## What

Recalibrate the completeness judge (`GeminiJudge` / `_DEFAULT_INSTRUCTIONS`). It treated tool-use as a **binary** — a tool call present → "work happened, done"; an output it couldn't see → "ungrounded" — with no model of whether investigation depth matched the ask. That misfired both ways.

## Why

Replaying recorded nisse production traces surfaced two judge errors:

- **False positive (the costly one).** Real, tool-sourced, post-training-cutoff data — e.g. June-2026 news with 3 corroborating links, or market figures from named research — got flagged "fabricated / from the future / ungrounded" and REDO'd up to the retry cap. This **degrades a correct answer** and burns ~2× cost on a near-duplicate the owner then sees.
- **False negative.** An open advisory ask answered from one or two snippet searches passed as "done" because a tool was called.

## The change

Two surgical edits to the instructions:

1. **Anti-cutoff-anchoring (the proven fix).** The judge's training cutoff is **not** the current date (given in the prompt); tool-sourced or cited data dated later than what it knows is **real**, not a hallucination or a date error. Flag fabrication only for a concrete claim with **no** tool call **and no** cited source.
2. **Depth-matches-the-ask gate.** Don't treat a tool call as automatic proof of enough work — but an answer already carrying named sources / real figures / a comparison **is** done (no redo for depth or style).

## Validation

Replayed catalogued production traces through the judge, 3 runs/case (gemini-flash is nondeterministic), via the nisse `replay-traces` skill:

- **3 false-positive cases flip REDO→PASS** robustly (3/3).
- **No regression** on 9 held PASS / REDO→PASS cases.
- One English-to-Russian case REDOs under **both** old and new prompt (identical) — a real language deficiency, not introduced here.

Cases + rationale live in nisse `docs/judge_test_cases.md` (companion PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
