### PR TITLE
feat(agents): tool calls can cost money; fold into the turn's cost

### DIFF
--- a/baski/agents/agent.py
+++ b/baski/agents/agent.py
@@ -18,7 +18,7 @@ from .execute_result import AgentExecuteResult
 from .judge import Judge, Verdict, retry_prompt
 from .message_history import EPHEMERAL_CACHE, MessageHistory
 from .pricing import ExecutionStats
-from .toolset import ToolSet, register_sub_trace
+from .toolset import ToolSet, register_sub_trace, report_cost
 from .trace import TraceCollector, TraceCollectorConfig
 
 logger = logging.getLogger(__name__)
@@ -241,6 +241,7 @@ class Agent:
             )
 
         tool_results = await self.toolset.execute(tool_calls)
+        stats.cost += sum(self.toolset.last_costs.values())  # tool spend (nested agents, paid APIs) joins the turn
         self.message_history.add_tool_results(tool_results)
         trace.record_tool_results(tool_results, self.toolset.last_timings, self.toolset.last_sub_trace_ids)
 
@@ -379,6 +380,7 @@ class Agent:
             raise
 
         await self.on_event(Completed(response=turn.message_to_user))
+        report_cost(stats.cost)  # if this agent ran as a tool, its total spend joins the caller's turn cost
 
         logger.info(
             "Agent execution complete",

--- a/baski/agents/toolset.py
+++ b/baski/agents/toolset.py
@@ -25,6 +25,18 @@ def register_sub_trace(trace_id: str) -> None:
         sink.append(trace_id)
 
 
+# Cost attributable to the running tool call — a nested Agent reports its own total, a paid tool its
+# API spend. The agent adds these to the turn's cost, so `total_cost` covers tools, not just the LLM.
+_sub_cost_sink: ContextVar[list[float] | None] = ContextVar("sub_cost_sink", default=None)
+
+
+def report_cost(usd: float) -> None:
+    """Attribute a USD cost to the currently-executing tool call (no-op outside one)."""
+    sink = _sub_cost_sink.get()
+    if sink is not None:
+        sink.append(usd)
+
+
 def _format_validation_error(tool_name: str, exc: ValidationError) -> str:
     """Render a pydantic error as a short, per-field message the model can act on."""
     lines = [f"Invalid input for tool '{tool_name}'. Fix these and call it again:"]
@@ -45,6 +57,7 @@ class ToolSet:
         self._tools: dict[str, Tool] = {}
         self.last_timings: dict[str, int] = {}
         self.last_sub_trace_ids: dict[str, list[str]] = {}  # tool_call.id → trace ids of agents it spawned
+        self.last_costs: dict[str, float] = {}  # tool_call.id → USD the tool reported (nested agents, paid APIs)
 
     def __contains__(self, tool_name: str) -> bool:
         """Return True if a tool with the given name is registered."""
@@ -122,6 +135,8 @@ class ToolSet:
         sink: list[str] = []
         self.last_sub_trace_ids[tool_call.id] = sink
         token = _sub_trace_sink.set(sink)  # a nested Agent this tool runs will register into `sink`
+        cost_sink: list[float] = []
+        cost_token = _sub_cost_sink.set(cost_sink)  # the tool (or a nested Agent) reports its cost here
 
         try:
             result = await tool.execute(**kwargs)
@@ -138,6 +153,8 @@ class ToolSet:
             )
         finally:
             _sub_trace_sink.reset(token)
+            _sub_cost_sink.reset(cost_token)
+            self.last_costs[tool_call.id] = sum(cost_sink)
 
         self.last_timings[tool_call.id] = int((time.monotonic() - start) * 1000)
         return ToolResultBlockParam(type="tool_result", tool_use_id=tool_call.id, content=result)
@@ -146,5 +163,6 @@ class ToolSet:
         """Execute tool calls in parallel and return formatted results."""
         self.last_timings = {}
         self.last_sub_trace_ids = {}
+        self.last_costs = {}
         results = await asyncio.gather(*[self._execute_single(tc) for tc in tool_calls])
         return list(results)


### PR DESCRIPTION
## What

A tool call can now carry a USD cost, and the agent folds it into that turn's cost — so `AgentExecuteResult.total_cost` reflects tools, not only the LLM.

## Why

A delegating sub-agent (agents-as-tools) runs its own `Agent` with its own spend, which never reached the caller's `total_cost`. For a research turn that delegates most of the work, the reported cost was a small fraction of the real one. Consumers (nisse's chat footer, logs, probe stats) showed a misleadingly low number.

## How

- `toolset.py` — `report_cost(usd)` attributes a cost to the currently-executing tool call via a `ContextVar` sink (the same shape as `sub_trace_ids`). `ToolSet.last_costs` maps `tool_call.id → USD`.
- `agent.py` — after `toolset.execute`, `stats.cost += sum(last_costs.values())`; at the end of `execute`, `report_cost(stats.cost)` so a nested Agent's *total* joins the caller's turn cost.

Roll-up is recursive and double-count-free: `retrieval` reports into `researcher`'s turn, `researcher`'s total reports into `main`'s turn. A future paid tool just calls `report_cost(x)` inside its `execute`.

## Test

`make ci` green (ruff, mypy, 40 tests). Verified end-to-end from nisse: a `main → retrieval` run reported `total_cost $0.1277` = main's own LLM `$0.0627` + the retrieval child's `$0.0650`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
