### PR TITLE
fix(judge): fail open when the Vertex judge is unavailable

### DIFF
--- a/baski/agents/agent.py
+++ b/baski/agents/agent.py
@@ -15,7 +15,7 @@ from baski.primitives import datetime
 from .events import Completed, Judged, Listener, TextDelta, Thinking, ToolFinished, ToolStarted, TurnStarted, noop
 from .events import Message as MessageEvent
 from .execute_result import AgentExecuteResult
-from .judge import Judge, Verdict, retry_prompt
+from .judge import Judge, JudgeUnavailableError, Verdict, retry_prompt
 from .message_history import EPHEMERAL_CACHE, MessageHistory
 from .pricing import ExecutionStats
 from .toolset import ToolSet
@@ -321,6 +321,23 @@ class Agent:
                         return str(block.get("text", ""))
         return ""
 
+    async def _grade(self, answer: str) -> Verdict | None:
+        """Grade the candidate answer for completeness, or None if the judge is unavailable.
+
+        Fail open: the judge is a best-effort quality gate, not a hard dependency. A judge outage
+        (e.g. Vertex 429 quota) must not sink an answer the agent already produced — None tells the
+        loop to accept the candidate rather than fail the whole run.
+        """
+        try:
+            return await self._judge.evaluate(
+                transcript=self.message_history.format_for_judge(),
+                answer=answer,
+                rules=await self._system(),
+            )
+        except JudgeUnavailableError as e:
+            logger.warning("Judge unavailable; accepting answer (fail open)", extra={"error": str(e)})
+            return None
+
     async def execute(self) -> AgentExecuteResult:
         """Drive the agentic loop over the current pinned context + history until done.
 
@@ -356,11 +373,9 @@ class Agent:
                 turn = await self._run_turn(stats, trace)
                 if turn.has_tool_calls:
                     continue  # model is still working — keep looping
-                verdict = await self._judge.evaluate(
-                    transcript=self.message_history.format_for_judge(),
-                    answer=turn.message_to_user or "",
-                    rules=await self._system(),
-                )
+                verdict = await self._grade(turn.message_to_user or "")
+                if verdict is None:
+                    break  # judge unavailable — fail open: accept the candidate answer
                 verdicts.append(verdict)
                 await self.on_event(
                     Judged(

--- a/baski/agents/judge.py
+++ b/baski/agents/judge.py
@@ -7,9 +7,11 @@ COMPLETENESS of the deliverable, not factual truth (transcript-checkable without
 """
 
 import logging
+from http import HTTPStatus
 from typing import Protocol
 
 from google import genai
+from google.genai import errors as genai_errors
 from google.genai import types as ai_types
 from pydantic import BaseModel, Field
 
@@ -18,6 +20,16 @@ from baski.primitives import datetime
 logger = logging.getLogger(__name__)
 
 DEFAULT_JUDGE_MODEL = "gemini-3.5-flash"  # cheap, fast, GA, different family from the Opus executor
+
+
+class JudgeUnavailableError(Exception):
+    """The judge couldn't render a verdict due to a transient outage.
+
+    Quota, 5xx, or network — NOT a fault in the answer. The Agent loop treats this as fail-open:
+    deliver the candidate answer rather than sink the whole run. Genuine judge defects (bad JSON,
+    4xx config errors) do NOT raise this — they surface loudly.
+    """
+
 
 _DEFAULT_INSTRUCTIONS = """\
 You grade whether an assistant's answer is DONE. Be CONSERVATIVE: a redo regenerates the entire answer
@@ -134,11 +146,16 @@ class GeminiJudge(Judge):
             f"<reply_to_grade>\n{answer}\n</reply_to_grade>\n\n"
             "Grade <reply_to_grade> for completeness, read in the context of <conversation>."
         )
-        response = await self._client.aio.models.generate_content(
-            model=self._model,
-            contents=prompt,
-            config=ai_types.GenerateContentConfig(response_mime_type="application/json", response_schema=Verdict),
-        )
+        try:
+            response = await self._client.aio.models.generate_content(
+                model=self._model,
+                contents=prompt,
+                config=ai_types.GenerateContentConfig(response_mime_type="application/json", response_schema=Verdict),
+            )
+        except genai_errors.APIError as e:
+            if e.code == HTTPStatus.TOO_MANY_REQUESTS or isinstance(e, genai_errors.ServerError):  # quota / outage
+                raise JudgeUnavailableError(f"Vertex judge call failed: {e.code} {e.status}") from e
+            raise  # 4xx config/request bug — surface it, don't fail open on a real defect
         if response.text is None:
             raise RuntimeError("Judge model returned no content")
         verdict = Verdict.model_validate_json(response.text)


### PR DESCRIPTION
## Problem

A production trace (`ff9938cc`, "Скажи выводы из этого видео") failed with `429 RESOURCE_EXHAUSTED` from Vertex. Root cause: the retrieval sub-agent's completeness judge (`GeminiJudge`, `gemini-3.5-flash` on Vertex) hit the project quota. The judge exception propagated out of the agent loop → the whole `retrieval` sub-agent call errored → the main agent got a tool error instead of the answer the worker had already produced.

The judge is a **best-effort quality gate, not a hard dependency** — its outage should never discard finished work.

## Fix

- `GeminiJudge.evaluate` catches `google.genai` `APIError` and translates **only transient failures** (429 quota, `ServerError` 5xx) into a new domain exception `JudgeUnavailableError`. Other 4xx (bad request/config) and malformed-JSON / `ValidationError` still raise loudly — a real judge defect must not be masked.
- The agent loop's new `_grade()` catches `JudgeUnavailableError`, logs a warning, and returns `None` → the loop **fails open** and delivers the candidate answer.

No blind `except Exception`; the fail-open path is a specific, documented, transient-only degrade. Layering stays clean: the provider-agnostic loop knows only the abstract `JudgeUnavailableError`, not `google.genai`.

## Verification

`ruff format` + `ruff check`, `mypy baski/`, `pytest` (40 passed) — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
