### PR TITLE
feat(agents): raise AgentBillingError on a too-low credit balance

### DIFF
--- a/baski/agents/__init__.py
+++ b/baski/agents/__init__.py
@@ -1,6 +1,6 @@
 """Agent framework for LLM-powered tool-use conversations."""
 
-from .agent import Agent, AgentConfig, AgentProviderUnavailableError, AgentRefusalError
+from .agent import Agent, AgentBillingError, AgentConfig, AgentProviderUnavailableError, AgentRefusalError
 from .events import (
     AgentEvent,
     Completed,
@@ -24,6 +24,7 @@ from .toolset import ToolSet
 __all__ = [
     "DEFAULT_JUDGE_MODEL",
     "Agent",
+    "AgentBillingError",
     "AgentConfig",
     "AgentEvent",
     "AgentExecuteResult",

--- a/baski/agents/agent.py
+++ b/baski/agents/agent.py
@@ -47,6 +47,24 @@ class AgentProviderUnavailableError(RuntimeError):
     """
 
 
+class AgentBillingError(RuntimeError):
+    """The Anthropic account can't be billed — a 400 whose message reports the credit balance is too low.
+
+    A billing problem to fix on our side (top up credits), not a transient outage or a malformed
+    request, so the caller can surface it with a distinct, actionable message instead of a generic error.
+    """
+
+
+def _is_billing_error(e: APIStatusError | APIConnectionError) -> bool:
+    """A 400 reporting the credit balance is too low — a billing issue to fix (top up), not an outage.
+
+    Anthropic has no dedicated status code for it, so match the message.
+    """
+    return (
+        isinstance(e, APIStatusError) and e.status_code == HTTPStatus.BAD_REQUEST and "credit balance" in str(e).lower()
+    )
+
+
 def _is_retriable(e: APIStatusError | APIConnectionError) -> bool:
     """A transient provider failure worth retrying — a connection blip or a 5xx/529 (overloaded) status.
 
@@ -162,7 +180,8 @@ class Agent:
         Raises AgentRefusalError on a `refusal` stop_reason — caught here, before the message
         reaches history, so the refused content never gets fed back in. A provider outage
         (5xx/529 or a connection failure) becomes AgentProviderUnavailableError once the retry
-        is exhausted; a 4xx (our own bug) re-raises as-is.
+        is exhausted; a 400 reporting a too-low credit balance becomes AgentBillingError; any other
+        4xx (our own bug) re-raises as-is.
         """
         max_retries = 1
         retry_count = 0
@@ -171,6 +190,8 @@ class Agent:
             try:
                 message = await self._stream_message(messages)
             except (APIStatusError, APIConnectionError) as e:
+                if _is_billing_error(e):
+                    raise AgentBillingError("Anthropic credit balance is too low") from e
                 if not _is_retriable(e):
                     raise
                 if retry_count < max_retries:


### PR DESCRIPTION
## Problem

Two production traces (`c401e7c8`, `f3065414`) failed at turn 0 with:

```
Error code: 400 - invalid_request_error
"Your credit balance is too low to access the Anthropic API. Please go to Plans & Billing…"
```

This 400 is non-retriable, so `_call_api` re-raised it as a raw `APIStatusError`. The caller (nisse) caught it in its generic `except Exception` and replied "Something went wrong on my side — please try again." — indistinguishable from a real bug, and giving the owner no hint that the actual fix is topping up credits.

## Fix

`_call_api` now recognizes the too-low-credit-balance 400 and raises a typed **`AgentBillingError`**, mirroring the existing `AgentRefusalError` / `AgentProviderUnavailableError` split. Detection is a message match (`status 400` + `"credit balance"`) because Anthropic has no dedicated status code for it. Any **other** 4xx still re-raises as-is (a genuine request bug stays loud).

Callers can now catch `AgentBillingError` and surface a distinct, actionable message. (nisse's chat router does this in a follow-up PR.)

## Verification

`ruff format` + `ruff check`, `mypy`, `pytest` (40 passed) — all green. Detection is grounded in the two real traces' error strings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
