### PR TITLE
feat(agents): cap the agentic loop with an aware turn budget (max_turns)

### DIFF
--- a/baski/agents/CLAUDE.md
+++ b/baski/agents/CLAUDE.md
@@ -29,6 +29,7 @@ Project-specific tools stay in the consuming project, NOT here. Canonical assemb
 ## Notes
 
 - Tracing is mandatory: every `execute()` requires a Mongo `database` and a GCS `bucket_name`.
+- **Turn budget** (`AgentConfig.max_turns`, default 40): a hard ceiling on the agentic loop. Every turn a volatile `[Turn n/max …]` line is injected (in `_build_messages`' trailing section, after the cache breakpoint) so the agent paces itself; the final allowed turn runs with `tool_choice=none` (`_run_turn` → `disable_tools`) so a runaway investigation always terminates in a synthesized answer, not more tool calls. Give a sub-agent a tighter value to keep research shallow. Independent of `judge_max_retries`.
 - Extended thinking is `adaptive`; parallel tool use enabled; `max_tokens=128_000`.
 - **Prompt caching**: cache breakpoints set in `agent.py` (tools, system) and `format_for_api` (history, via `mark_cached`). Invariant when adding anything to the prompt — volatile/per-turn content (time, context footer, `user_message()` injections) must go AFTER the last breakpoint; keep it in `_build_messages`' trailing section, never inside `format_for_api`. `mark_cached` must stay copy-safe (mutating a stored turn would persist `cache_control`).
 - Size context only via `pricing.effective_input_tokens` — caching hides cached tokens from `usage.input_tokens`, so a `truncate` reading it raw never trims.

--- a/baski/agents/agent.py
+++ b/baski/agents/agent.py
@@ -109,6 +109,11 @@ class AgentConfig(NamedTuple):
     await_trace: bool = False  # block reply on trace persistence (tests/probe read it right after)
     local_traces_dir: str | None = None  # write full traces here instead of GCS (tests/probe); None → GCS
     judge_max_retries: int = 2  # cap on judge-driven re-runs, so an unsatisfiable check never spins
+    # Hard ceiling on the agentic loop: at most this many API turns. The agent is told its turn budget
+    # every turn so it paces itself, and the final allowed turn runs with tools disabled so it must
+    # synthesize an answer from what it has instead of running an investigation ever deeper. Generous by
+    # default (a safety net for the main agent); a sub-agent passes a tighter value to keep research shallow.
+    max_turns: int = 40
 
 
 class Agent:
@@ -130,6 +135,7 @@ class Agent:
         self._local_traces_dir = config.local_traces_dir
         self._judge = config.judge
         self._judge_max_retries = config.judge_max_retries
+        self._max_turns = config.max_turns
         self.on_event = on_event
         # Not in message_history.turns, so truncate/prune_transcript can't reach it.
         self._pinned: list[MessageParam] = []
@@ -164,17 +170,22 @@ class Agent:
         """Assemble the system prompt fresh — tool contributions (e.g. owner preferences) can change per turn."""
         return f"{self._system_prompt}\n\n{await self.toolset.system_prompt()}\n\n{AGENT_LOOP_GUIDANCE}"
 
-    async def _stream_message(self, messages: list[MessageParam]) -> Message:
-        """Stream one response, emitting each text delta to the listener; return the assembled message."""
+    async def _stream_message(self, messages: list[MessageParam], *, disable_tools: bool = False) -> Message:
+        """Stream one response, emitting each text delta to the listener; return the assembled message.
+
+        `disable_tools` forces `tool_choice=none` for this one call (the loop's final turn) so the model
+        must answer from what it has — a per-call override that never mutates the shared, re-used params.
+        """
+        params = self.params | {"tool_choice": {"type": "none"}} if disable_tools else self.params
         async with self.anthropic_client.messages.stream(
             messages=messages,
-            **self.params,  # type: ignore[arg-type]  # params is a dynamic dict merged with caller overrides
+            **params,  # type: ignore[arg-type]  # params is a dynamic dict merged with caller overrides
         ) as stream:
             async for text in stream.text_stream:
                 await self.on_event(TextDelta(text=text))
             return await stream.get_final_message()
 
-    async def _call_api(self, messages: list[MessageParam]) -> Message:
+    async def _call_api(self, messages: list[MessageParam], *, disable_tools: bool = False) -> Message:
         """Streaming API call with one retry on a transient provider error (2s backoff).
 
         Raises AgentRefusalError on a `refusal` stop_reason — caught here, before the message
@@ -188,7 +199,7 @@ class Agent:
 
         while retry_count <= max_retries:
             try:
-                message = await self._stream_message(messages)
+                message = await self._stream_message(messages, disable_tools=disable_tools)
             except (APIStatusError, APIConnectionError) as e:
                 if _is_billing_error(e):
                     raise AgentBillingError("Anthropic credit balance is too low") from e
@@ -227,22 +238,45 @@ class Agent:
 
         return ParsedResponse(tool_calls=tool_calls, text_blocks=text_blocks)
 
-    async def _build_messages(self) -> list[MessageParam]:
-        """Build the full message list for an API call: pinned context, then the history."""
+    def _turn_budget_message(self, turn_number: int, *, force_answer: bool) -> MessageParam:
+        """The volatile per-turn budget line, so the agent knows how much loop it has left and paces itself.
+
+        On the final turn (`force_answer`, tools disabled) it says answer now; otherwise it counts down.
+        """
+        if force_answer:
+            text = (
+                f"[Turn {turn_number}/{self._max_turns} — final turn, tools are OFF. "
+                "Give your complete final answer NOW from what you already have.]"
+            )
+        else:
+            left = self._max_turns - turn_number
+            text = (
+                f"[Turn {turn_number}/{self._max_turns} — {left} turn(s) left before you must give your final "
+                "answer. Spend tool calls deliberately and synthesize in time; don't research deeper than needed.]"
+            )
+        return MessageParam(role="user", content=[TextBlockParam(type="text", text=text)])
+
+    async def _build_messages(self, turn_number: int, *, force_answer: bool) -> list[MessageParam]:
+        """Build the full message list for an API call: pinned context, then the history.
+
+        `turn_number`/`force_answer` drive the volatile turn-budget line, so the agent sees how much of
+        its loop it has spent and when it must deliver a final answer.
+        """
         now = datetime.now()
         time_message = MessageParam(
             role="user",
             content=[TextBlockParam(type="text", text=f"Current time: {now.strftime('%A, %B %d, %Y %I:%M %p %Z')}")],
         )
         # Stable prefix (pinned + history, cache breakpoint on the last turn) first; volatile blocks
-        # after it so they don't invalidate the cache: context footer, per-turn user_message()
-        # injections, then time (changes every minute).
+        # after it so they don't invalidate the cache: context footer, turn budget, per-turn
+        # user_message() injections, then time (changes every minute).
         history = self.message_history.format_for_api()
         status = self.message_history.context_status()
         return [
             *self._pinned,
             *history,
             *([status] if status else []),
+            self._turn_budget_message(turn_number, force_answer=force_answer),
             *await self.toolset.user_messages(),
             time_message,
         ]
@@ -300,14 +334,20 @@ class Agent:
         return text
 
     async def _run_turn(self, stats: ExecutionStats, trace: TraceCollector) -> TurnResult:
-        """Run a single agentic turn: build messages, call API, parse response, execute tools."""
-        messages = await self._build_messages()
+        """Run a single agentic turn: build messages, call API, parse response, execute tools.
+
+        The final turn of the budget (`force_answer`) runs with tools disabled, so a runaway
+        investigation always terminates in a synthesized answer instead of yet more tool calls.
+        """
+        turn_number = stats.turn_count + 1  # turn_count counts COMPLETED turns; this is the one about to run
+        force_answer = turn_number >= self._max_turns
+        messages = await self._build_messages(turn_number, force_answer=force_answer)
         trace.start_turn(messages)
 
         start = time.monotonic()
         # Reassembled each turn — tool guidance can be live.
         self.params["system"] = [TextBlockParam(type="text", text=await self._system(), cache_control=EPHEMERAL_CACHE)]
-        message = await self._call_api(messages)
+        message = await self._call_api(messages, disable_tools=force_answer)
         api_duration_ms = int((time.monotonic() - start) * 1000)
 
         stats.collect(message.usage)


### PR DESCRIPTION
## What

Adds `AgentConfig.max_turns` (default **40**) — a hard ceiling on the agentic loop, plus per-turn awareness so the agent paces itself instead of being cut off.

**Motivation:** during research the sub-agents go too deep — the loop keeps calling tools well past the point of diminishing returns. This gives a real ceiling the agent *knows about*.

## How

- **Awareness:** every turn injects a volatile `[Turn n/max — N turn(s) left …]` line (in `_build_messages`' trailing section, after the cache breakpoint — respecting the caching invariant), so the model budgets its remaining tool calls.
- **Enforcement:** the final allowed turn (`turn_number >= max_turns`) runs with `tool_choice={"type":"none"}` (threaded via `_call_api(disable_tools=…)` as a per-call override — never mutating the shared, re-used params), so a runaway investigation always terminates in a *synthesized answer* rather than more tool calls or an empty response.
- Independent of `judge_max_retries`. Default 40 is a generous safety net so the main agent's behaviour is unchanged; sub-agents pass a tighter value (nisse PR follows).

## Verify

- `make lint` ✅
- Budget line checked at boundaries (max_turns=8): turn 1 → "7 left", turn 7 → "1 left", turn 8 → "final turn, tools are OFF".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
