### PR TITLE
fix(telegram): declare webhook allowed_updates from registered handlers

### DIFF
--- a/baski/telegram/server.py
+++ b/baski/telegram/server.py
@@ -114,9 +114,19 @@ class TelegramServer(AsyncServer):
 
         @asynccontextmanager
         async def lifespan(_: FastAPI) -> AsyncIterator[None]:
+            # Declare allowed_updates from the registered handlers. Telegram delivers ONLY the update
+            # types listed on the webhook, and omitting the field silently keeps whatever was set before
+            # — so a bot that adds e.g. a callback_query handler would never receive its taps until the
+            # webhook is re-set. Derive it from the dispatcher and re-apply on any drift (or url change).
             info = await self.bot.get_webhook_info()
-            if info.url != webhook_url:
-                await retry(self.bot.set_webhook, exceptions=(TelegramAPIError,), url=webhook_url)
+            allowed = self.dp.resolve_used_update_types()
+            if info.url != webhook_url or set(info.allowed_updates or []) != set(allowed):
+                await retry(
+                    self.bot.set_webhook,
+                    exceptions=(TelegramAPIError,),
+                    url=webhook_url,
+                    allowed_updates=allowed,
+                )
             # feed_webhook_update never fires the dispatcher startup/shutdown events that
             # start_polling emits, so router on_startup hooks (client init) must be driven here.
             await self.dp.emit_startup(bot=self.bot)


### PR DESCRIPTION
## Problem

`_run_webhook` set the webhook with **no** `allowed_updates`, and only when the URL changed. Telegram's rule: omit `allowed_updates` → **keep the previous setting**. So a webhook once pinned to `["message"]` stayed message-only forever, and every `callback_query` (inline-button tap) was dropped by Telegram before reaching the worker.

Downstream impact (nisse): the new `ask_user` human-in-the-loop tool sends an inline keyboard and awaits the tap — which never arrived, so it hung until its timeout. Diagnosed via `getWebhookInfo` showing `allowed_updates: ["message"]`.

## Fix

Derive `allowed_updates` from `dp.resolve_used_update_types()` (the update types the registered handlers actually consume) and re-set the webhook when the live `allowed_updates` **or** URL drifts from it:

```python
allowed = self.dp.resolve_used_update_types()
if info.url != webhook_url or set(info.allowed_updates or []) != set(allowed):
    await retry(self.bot.set_webhook, ..., url=webhook_url, allowed_updates=allowed)
```

Adding a handler for a new update type now takes effect on the next startup, by construction — no manual `setWebhook`. This mirrors what `start_polling` already does automatically (it resolves used update types when `allowed_updates` isn't passed).

Verified `resolve_used_update_types()` returns `['callback_query', 'message']` for a dispatcher with both handlers registered.

## Verify
`ruff` + `mypy` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)