### PR TITLE
feat(lint): ship the AST rules as `baski.lint`, add ANON003

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,13 +9,13 @@ setup:
 lint:
 	uv run ruff format --check baski/
 	uv run ruff check baski/
-	uv run python anon_lint.py --recursive baski/
+	uv run python -m baski.lint --recursive baski/
 
 .PHONY: lint-fix
 lint-fix:
 	uv run ruff format baski/
 	uv run ruff check baski/ --fix
-	uv run python anon_lint.py --recursive baski/
+	uv run python -m baski.lint --recursive baski/
 
 .PHONY: typecheck
 typecheck:

--- a/baski/lint/__init__.py
+++ b/baski/lint/__init__.py
@@ -1,0 +1,11 @@
+"""Project-agnostic AST lint rules, shared by every project built on baski.
+
+Lives inside the package rather than at the repo root on purpose: a root-level `anon_lint.py` is
+importable as a top-level module by anything that has this repo on `sys.path` — which every editable
+consumer does — so a consumer's own copy is silently shadowed depending on how the interpreter was
+started. `baski.lint` can only ever resolve to one thing.
+"""
+
+from baski.lint.anon import Config, Finding, format_finding, lint_file, lint_source, main
+
+__all__ = ["Config", "Finding", "format_finding", "lint_file", "lint_source", "main"]

--- a/baski/lint/__main__.py
+++ b/baski/lint/__main__.py
@@ -1,0 +1,7 @@
+"""`python -m baski.lint <files_or_dirs...> [--recursive]`."""
+
+import sys
+
+from baski.lint.anon import main
+
+sys.exit(main())

--- a/baski/lint/anon.py
+++ b/baski/lint/anon.py
@@ -1,7 +1,14 @@
-"""anon-lint: ban anonymous tuple/dict in function/class type annotations.
+"""anon-lint: AST rules for smells ruff has no check for.
+
+- ANON001/ANON002 — ban anonymous tuple/dict in function/class type annotations.
+- ANON003 — ban a long-lived dependency (client, database, bot, store) in a free function's
+  parameters: it is a method missing its class, and behaviour with no home object is behaviour the
+  next reader writes a second copy of. Which type names count is per-project, so the list is read
+  from `[tool.anon_lint]` in the nearest `pyproject.toml`; the built-in defaults below cover the
+  third-party clients every consumer of this library already holds.
 
 Run as:
-    python -m anon_lint <files_or_dirs...> [--recursive]
+    python -m baski.lint <files_or_dirs...> [--recursive]
 
 Tests live in tests/test_anon_lint.py and run under `uv run pytest`.
 """
@@ -12,7 +19,9 @@ import argparse
 import ast
 import re
 import sys
+import tomllib
 from dataclasses import dataclass
+from functools import cache
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -23,13 +32,62 @@ DICT_LIKE = {"dict", "Dict", "Mapping", "MutableMapping"}
 TUPLE_LIKE = {"tuple", "Tuple"}
 ANY_NAMES = {"Any"}
 
+# ANON003 defaults: third-party clients any consumer of this library may hold. A project's OWN
+# collaborators are not guessable from here — it adds them under `[tool.anon_lint]` (see `_config`).
+# Deliberately absent: a deps/container object. Passing one is the whole point of having it.
+DEPENDENCY_TYPES = {
+    "AsyncAnthropic",
+    "AsyncClient",  # httpx
+    "AsyncCollection",
+    "AsyncDatabase",
+    "AsyncElevenLabs",
+    "Bot",
+    "PlaywrightClient",
+    "Scheduler",
+    "SerpApiClient",
+}
+# Naming conventions that mark a collaborator without having to enumerate every one.
+DEPENDENCY_SUFFIXES = ("Store", "Log", "Registry")
+
 # A tuple annotation needs at least this many element types before we flag it
 # as anonymous (single-element tuples are usually `tuple[X]` containers).
 _TUPLE_MIN_FLAG_ELEMENTS = 2
 # A dict annotation must have exactly key + value to be a candidate.
 _DICT_SLICE_ELEMENTS = 2
 
-NOQA_RE = re.compile(r"#\s*noqa\s*:\s*([A-Za-z0-9, ]+)")
+# Codes only — the reason text that follows must NOT be swallowed into the last code, or
+# `# noqa: ANON003 wraps one library call` suppresses nothing while looking like it does.
+NOQA_RE = re.compile(r"#\s*noqa\s*:\s*([A-Za-z]+[0-9]+(?:\s*,\s*[A-Za-z]+[0-9]+)*)")
+
+
+@dataclass(frozen=True)
+class Config:
+    """Which type names ANON003 treats as a long-lived dependency, for one project."""
+
+    dependency_types: frozenset[str]
+    dependency_suffixes: tuple[str, ...]
+
+
+DEFAULT_CONFIG = Config(frozenset(DEPENDENCY_TYPES), DEPENDENCY_SUFFIXES)
+
+
+@cache
+def _config(start: Path) -> Config:
+    """Read `[tool.anon_lint]` from the nearest `pyproject.toml` at or above `start`.
+
+    Walking up rather than taking a flag: the linter is invoked from a project's own Makefile, so
+    the project it is linting is the one it sits inside. `extend_dependency_types` adds to the
+    built-in defaults; `dependency_types` replaces them outright.
+    """
+    for directory in (start, *start.parents):
+        manifest = directory / "pyproject.toml"
+        if not manifest.is_file():
+            continue
+        table = tomllib.loads(manifest.read_text(encoding="utf-8")).get("tool", {}).get("anon_lint", {})
+        types = set(table.get("dependency_types", DEPENDENCY_TYPES)) | set(table.get("extend_dependency_types", []))
+        suffixes = tuple(table.get("dependency_suffixes", DEPENDENCY_SUFFIXES))
+        return Config(frozenset(types), suffixes)
+    return DEFAULT_CONFIG
 
 
 @dataclass(frozen=True)
@@ -86,15 +144,74 @@ def _is_typealias(annotation: ast.expr | None) -> bool:
     return annotation is not None and _name_of(annotation) == "TypeAlias"
 
 
+def _annotation_names(annotation: ast.expr | None) -> Iterator[str]:
+    """Every type name an annotation could resolve to.
+
+    Unwraps each spelling the same parameter takes: `X`, `X[...]`, `pkg.X`, a quoted `"X"` under
+    TYPE_CHECKING, and `X | None` / `Optional[X]` — otherwise appending ` | None` is a one-token way
+    to silence ANON003 while changing nothing about the design it catches.
+    """
+    if annotation is None:
+        return
+    if isinstance(annotation, ast.Constant) and isinstance(annotation.value, str):
+        try:
+            annotation = ast.parse(annotation.value, mode="eval").body
+        except SyntaxError:
+            return
+    if isinstance(annotation, ast.BinOp) and isinstance(annotation.op, ast.BitOr):
+        yield from _annotation_names(annotation.left)
+        yield from _annotation_names(annotation.right)
+        return
+    if isinstance(annotation, ast.Subscript) and _subscript_base(annotation) == "Optional":
+        yield from _annotation_names(annotation.slice)
+        return
+    name = _subscript_base(annotation) or _name_of(annotation)
+    if name is not None:
+        yield name
+
+
+def _dependency_name(annotation: ast.expr | None, config: Config) -> str | None:
+    """The dependency type this annotation names, or None if it names none."""
+    return next(
+        (
+            n
+            for n in _annotation_names(annotation)
+            if n in config.dependency_types or n.endswith(config.dependency_suffixes)
+        ),
+        None,
+    )
+
+
 def _subscript_base(node: ast.expr) -> str | None:
     return _name_of(node.value) if isinstance(node, ast.Subscript) else None
 
 
 class _Checker:
-    def __init__(self, source_lines: list[str], path: Path) -> None:
+    def __init__(self, source_lines: list[str], path: Path, config: Config = DEFAULT_CONFIG) -> None:
         self.source_lines = source_lines
         self.path = path
+        self.config = config
         self.findings: list[Finding] = []
+
+    def check_free_function_deps(self, fn: ast.FunctionDef | ast.AsyncFunctionDef) -> None:
+        """Flag a module-level function that takes a long-lived collaborator as a parameter."""
+        args = fn.args
+        for arg in [*args.posonlyargs, *args.args, *args.kwonlyargs]:
+            dependency = _dependency_name(arg.annotation, self.config)
+            if dependency is None:
+                continue
+            if self._suppressed(fn.lineno, "ANON003"):
+                return
+            self.findings.append(
+                Finding(
+                    self.path,
+                    fn.lineno,
+                    fn.col_offset,
+                    "ANON003",
+                    f"{fn.name}({arg.arg}: {dependency}) — bind it in a class, don't pass it per call",
+                )
+            )
+            return  # one finding per function; the fix is the same whichever parameter tripped it
 
     def _suppressed(self, line: int, code: str) -> bool:
         if line < 1 or line > len(self.source_lines):
@@ -179,13 +296,21 @@ def _check_function(fn: ast.FunctionDef | ast.AsyncFunctionDef, checker: _Checke
     checker.check_annotation(fn.returns)
 
 
-def lint_source(source: str, path: Path) -> list[Finding]:
+def _check_module_level(tree: ast.Module, checker: _Checker) -> None:
+    """ANON003 pass. Module-level functions only — a method is already bound to its collaborators."""
+    for node in tree.body:
+        if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
+            checker.check_free_function_deps(node)
+
+
+def lint_source(source: str, path: Path, config: Config = DEFAULT_CONFIG) -> list[Finding]:
     """Run the checker on a single source string; return all findings (may be empty)."""
     try:
         tree = ast.parse(source)
     except SyntaxError:
         return []
-    checker = _Checker(source.splitlines(), path)
+    checker = _Checker(source.splitlines(), path, config)
+    _check_module_level(tree, checker)
     for node in ast.walk(tree):
         if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
             _check_function(node, checker)
@@ -198,12 +323,16 @@ def lint_source(source: str, path: Path) -> list[Finding]:
 
 
 def lint_file(path: Path) -> list[Finding]:
-    """Read a file from disk and lint it; silently skips unreadable paths."""
+    """Read a file from disk and lint it; silently skips unreadable paths.
+
+    The ANON003 config comes from the file's own project, so linting a path outside this repo still
+    uses that project's dependency list rather than this one's.
+    """
     try:
         source = path.read_text(encoding="utf-8")
     except OSError:
         return []
-    return lint_source(source, path)
+    return lint_source(source, path, _config(path.resolve().parent))
 
 
 def iter_files(targets: Iterable[Path], *, recursive: bool) -> Iterator[Path]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@ target-version = "py312"
 
 [tool.ruff.lint]
 select = ["ALL"]
-external = ["ANON001", "ANON002"]  # anon_lint.py custom rules
+external = ["ANON001", "ANON002", "ANON003"]  # baski.lint custom rules
 ignore = [
     # Formatter conflicts
     "COM812",

--- a/tests/test_anon_lint.py
+++ b/tests/test_anon_lint.py
@@ -1,22 +1,19 @@
-"""Tests for anon_lint.py — the anonymous-tuple/dict checker.
+"""Tests for `baski.lint` — the anonymous-tuple/dict checker (ANON001/002) and the free-function
+dependency checker (ANON003).
 
-Run via the standard `uv run pytest` invocation; lives at the repo root so
-the project-wide `make test` picks it up alongside the per-plugin suites.
+A lint rule that silently stops matching is worse than no rule: `make lint` is green either way. So
+each test below is written to die on a specific way the checker could break, and the CLI test covers
+the exit code, which is the only thing the build actually reads.
 """
 
 from __future__ import annotations
 
-import sys
 import textwrap
 from pathlib import Path
 
 import pytest
 
-_ROOT = Path(__file__).resolve().parent.parent
-if str(_ROOT) not in sys.path:
-    sys.path.insert(0, str(_ROOT))
-
-from anon_lint import lint_source  # noqa: E402
+from baski.lint import Config, lint_source, main
 
 _FIRES = [
     ("def f() -> tuple[str, int]: ...", {"ANON001"}),
@@ -77,3 +74,149 @@ def test_nested_tuple_in_dict_value() -> None:
     src = "def f() -> dict[str, tuple[int, int]]: ...\n"
     findings = lint_source(src, Path("x.py"))
     assert "ANON001" in {f.code for f in findings}
+
+
+# ── ANON003: a dependency in a free function's parameters ──
+
+_CONFIG = Config(frozenset({"AsyncAnthropic", "AsyncDatabase", "Bot"}), ("Store", "Log"))
+
+
+def _anon003(src: str) -> list[str]:
+    return [f.code for f in lint_source(textwrap.dedent(src), Path("x.py"), _CONFIG)]
+
+
+def test_a_free_function_taking_a_client_is_flagged() -> None:
+    """The shape the rule exists for: the client is threaded in at every call site.
+
+    Position is asserted, not just the code — a finding anchored anywhere but the `def` line makes
+    both the report and the `# noqa` escape hatch point at the wrong place.
+    """
+    src = "async def classify(anthropic: AsyncAnthropic, evidence: Evidence) -> Classification: ...\n"
+
+    (finding,) = lint_source(src, Path("x.py"), _CONFIG)
+
+    assert (finding.code, finding.line, finding.col) == ("ANON003", 1, 0)
+    assert "classify(anthropic: AsyncAnthropic)" in finding.message
+
+
+def test_every_parameter_kind_counts() -> None:
+    """Keyword-only is how most collaborators are actually written (`def f(*, database: ...)`), so a
+    rule that only walked positional parameters would miss the shape it was written for."""
+    assert _anon003("def a(database: AsyncDatabase) -> None: ...") == ["ANON003"]
+    assert _anon003("def b(*, database: AsyncDatabase) -> None: ...") == ["ANON003"]
+    assert _anon003("def c(bot: Bot, /) -> None: ...") == ["ANON003"]
+    assert _anon003("async def d(*, bot: Bot) -> None: ...") == ["ANON003"]
+
+
+def test_the_suffix_convention_counts_without_enumerating_every_type() -> None:
+    assert _anon003("def a(store: MemoryStore) -> None: ...") == ["ANON003"]
+    assert _anon003("def b(log: RevisionLog) -> None: ...") == ["ANON003"]
+
+
+def test_a_method_is_not_flagged_because_it_is_already_bound() -> None:
+    """The fix for ANON003 is "make it a method" — flagging methods would close the only exit."""
+    assert _anon003("class C:\n    def take(self, database: AsyncDatabase) -> None: ...\n") == []
+
+
+def test_making_the_dependency_optional_does_not_silence_it() -> None:
+    """Otherwise ` | None` is a one-token way to shut the rule up without changing the design — and
+    an optional dependency is a worse smell, not an exemption."""
+    assert _anon003("def a(store: MemoryStore | None) -> None: ...") == ["ANON003"]
+    assert _anon003("def b(store: Optional[MemoryStore]) -> None: ...") == ["ANON003"]
+    assert _anon003('def c(store: "MemoryStore | None") -> None: ...') == ["ANON003"]
+
+
+def test_generic_and_quoted_spellings_count() -> None:
+    """`"X"` under TYPE_CHECKING and `X[Any]` are the other two ways the same parameter is written."""
+    assert _anon003('def a(store: "MemoryStore") -> None: ...') == ["ANON003"]
+    assert _anon003("def b(db: AsyncDatabase[Any]) -> None: ...") == ["ANON003"]
+
+
+def test_a_pure_helper_over_primitives_is_left_alone() -> None:
+    """The rule must not push stateless helpers into classes — that would trade duplication for
+    ceremony, which is a worse deal."""
+    assert _anon003("def split_message(text: str, limit: int = 4096) -> list[str]: ...") == []
+
+
+def test_one_finding_per_function_even_with_several_dependencies() -> None:
+    """The fix is the same whichever parameter tripped it; three lines of noise per function would
+    train the eye to skip the rule."""
+    assert _anon003("def fire(database: AsyncDatabase, bot: Bot, store: MemoryStore) -> None: ...") == ["ANON003"]
+
+
+def test_a_type_outside_this_projects_config_is_not_flagged() -> None:
+    """The type list is per-project — a name this project never configured is just a name."""
+    assert _anon003("def a(questions: PendingQuestions) -> None: ...") == []
+
+
+def test_noqa_suppresses_it_on_the_def_line_of_a_wrapped_signature() -> None:
+    """A documented exception has to be expressible, or the rule is deleted the first time it is
+    inconvenient — and signatures wrap, so the `def` line and the offending parameter differ."""
+    assert _anon003("def fire(  # noqa: ANON003 — wraps one library call\n    db: AsyncDatabase,\n) -> None: ...\n") == []
+
+
+def test_the_noqa_reason_may_be_written_any_way_and_still_suppresses() -> None:
+    """A noqa is expected to carry a reason, so the reason text must not be parsed as part of the
+    code — otherwise the documented form is the one that silently fails to suppress."""
+    for comment in ("# noqa: ANON003 — wraps one call", "# noqa: ANON003 wraps one call", "# noqa: ANON003"):
+        assert _anon003(f"def f(db: AsyncDatabase) -> None:  {comment}\n    ...\n") == [], comment
+
+
+# ── the CLI, which is the only thing `make lint` reads ──
+
+
+def test_the_cli_exits_nonzero_and_names_the_spot(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """Every other test calls `lint_source` directly and would stay green with `main` returning 0
+    unconditionally — the "green forever, catches nothing" failure this file exists to stop.
+
+    Uses ANON003 so the built-in dependency defaults are exercised too: `tmp_path` has no
+    `pyproject.toml`, so this is the path a project that configures nothing takes.
+    """
+    violator = tmp_path / "violator.py"
+    violator.write_text("def f(database: AsyncDatabase) -> None: ...\n", encoding="utf-8")
+
+    exit_code = main([str(violator)])
+
+    assert exit_code == 1
+    assert f"{violator}:1:0: ANON003" in capsys.readouterr().out
+
+
+def test_the_cli_exits_zero_on_clean_input(tmp_path: Path) -> None:
+    """The other half: a rule that fails on everything gets switched off within a day."""
+    clean = tmp_path / "clean.py"
+    clean.write_text("def f(text: str) -> str: ...\n", encoding="utf-8")
+
+    assert main([str(clean)]) == 0
+
+
+# ── per-project configuration, the reason ANON003 can live in a shared library at all ──
+
+
+def _project(tmp_path: Path, table: str, source: str) -> Path:
+    (tmp_path / "pyproject.toml").write_text(f"[tool.anon_lint]\n{table}\n", encoding="utf-8")
+    module = tmp_path / "m.py"
+    module.write_text(source, encoding="utf-8")
+    return module
+
+
+def test_a_project_can_name_its_own_collaborators(tmp_path: Path) -> None:
+    """A shared library cannot know a consumer's own types, so without this the rule would only ever
+    catch third-party clients — which are the minority of any project's dependencies."""
+    module = _project(tmp_path, 'extend_dependency_types = ["Widget"]', "def f(w: Widget) -> None: ...\n")
+
+    assert main([str(module)]) == 1
+
+
+def test_extending_keeps_the_built_in_defaults(tmp_path: Path) -> None:
+    """`extend_` must add to the defaults, not silently replace them — otherwise naming one type
+    turns the third-party checks off without saying so."""
+    module = _project(tmp_path, 'extend_dependency_types = ["Widget"]', "def f(db: AsyncDatabase) -> None: ...\n")
+
+    assert main([str(module)]) == 1
+
+
+def test_setting_the_list_outright_replaces_the_defaults(tmp_path: Path) -> None:
+    """The escape hatch for a project whose stack shares none of the default names."""
+    module = _project(tmp_path, 'dependency_types = ["Widget"]', "def f(db: AsyncDatabase) -> None: ...\n")
+
+    assert main([str(module)]) == 0


### PR DESCRIPTION
Линтер переезжает внутрь пакета и получает третье правило.

## Почему из корня

`anon_lint.py` лежал в корне репозитория, а корень baski попадает в `sys.path` у любого потребителя с editable-зависимостью. Значит модуль верхнего уровня `anon_lint` импортируется откуда угодно — и потребитель со своей копией получает то одну, то другую, в зависимости от того, как запущен интерпретатор: pytest берёт свою (его конфиг ставит корень проекта первым), обычный `python scripts/x.py` — эту.

Это не гипотеза: две копии уже разошлись под этим прикрытием, и я сам на этом попался — три проверки подряд отвечали «дыры нет», потому что линтили чужим файлом. `baski.lint` может разрешиться только в одно.

## ANON003

Ловит module-level `def`, у которого параметр аннотирован долгоживущей зависимостью — клиентом, базой, ботом, стором. Такая функция это метод без класса, а поведение без объекта-владельца — это поведение, которому следующий читатель напишет вторую копию.

Методы не флагаются: «сделай это методом» и есть починка, флажить их значило бы закрыть выход.

## Список типов — за проектом

Библиотека не может знать, какие классы у потребителя долгоживущие. Поэтому список читается из `[tool.anon_lint]` в ближайшем `pyproject.toml`:

```toml
[tool.anon_lint]
extend_dependency_types = ["PendingQuestions", "SchedulingService", "Transcriber"]
# или, чтобы заменить встроенные целиком:
# dependency_types = ["Widget"]
```

Проект, который не настроил ничего, получает встроенные дефолты (сторонние клиенты), а не правило, которое молча ничего не матчит.

## Побочно: сломанный `noqa`

Общая регулярка забирала текст причины внутрь последнего кода — `# noqa: ANON001 legacy shape` не глушил ничего, хотя выглядел как глушащий. Работало это только потому, что все существующие `noqa` в обоих репозиториях отделяют причину длинным тире, которое не входило в класс символов.

## Тесты: 12 → 42

Каждый написан так, чтобы умереть от конкретной поломки, и это проверено обратной мутацией:

- exit-код `main()` — единственное, что читает `make lint`; без него `return 0` оставлял бы сборку зелёной навсегда;
- keyword-only и positional-only параметры;
- строка, на которую садится находка (перенос якоря ломает `noqa` на многострочной сигнатуре);
- `X | None` и `Optional[X]` — иначе один токен глушит правило;
- чтение конфига из `pyproject.toml`: и `extend_`, и полная замена.

## Проверено

`make lint`, `make typecheck`, `make test` — 53 теста. Упаковка проверена сборкой колеса, а не чтением конфига: `baski/lint/{__init__,__main__,anon}.py` внутри.

## Дальше

Следующим PR nisse удаляет свою копию, объявляет свой список в `pyproject.toml` и переходит на `python -m baski.lint`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PWRbL7sRe2F5xJh7xt68y5
