### PR TITLE
perf(agents): live tool content rides after the cache breakpoint

### DIFF
--- a/baski/agents/agent.py
+++ b/baski/agents/agent.py
@@ -25,6 +25,11 @@ logger = logging.getLogger(__name__)
 
 DEFAULT_MODEL = "claude-opus-4-8"
 
+# Models that accept a `system`-role message inside `messages[]`. It is the operator channel for
+# context that arrives mid-conversation, and unlike editing the top-level system prompt it leaves
+# the cached history intact. Sonnet 5 is deliberately absent — it rejects the role.
+MID_CONVERSATION_SYSTEM_MODELS = frozenset({"claude-opus-5", "claude-opus-4-8", "claude-fable-5", "claude-mythos-5"})
+
 AGENT_LOOP_GUIDANCE = (
     "Always use the most appropriate tool. Use parallel tool calls when they are independent\n"
     "Provide brief explanation of your reasoning for when you use tools and what are next steps."
@@ -167,8 +172,26 @@ class Agent:
         self.add_pinned(MessageParam(role="user", content=[TextBlockParam(type="text", text=text)]))
 
     async def _system(self) -> str:
-        """Assemble the system prompt fresh — tool contributions (e.g. owner preferences) can change per turn."""
+        """Assemble the system prompt from the parts that stay byte-identical across turns.
+
+        Anything a tool rewrites while the agent works is excluded here and delivered after the
+        cached prefix instead (`_live_context`) — a system block that changes invalidates every
+        cached message behind it.
+        """
         return f"{self._system_prompt}\n\n{await self.toolset.system_prompt()}\n\n{AGENT_LOOP_GUIDANCE}"
+
+    async def _live_context(self) -> MessageParam | None:
+        """The tools' per-turn changing content, as a trailing message rather than a system edit.
+
+        A `system`-role message is the operator channel and keeps the cached history intact, but only
+        some models accept one mid-conversation; everywhere else the content falls back to a user
+        block, which caches identically and differs only in authority.
+        """
+        live = await self.toolset.live_system_prompt()
+        if not live:
+            return None
+        role = "system" if str(self.params["model"]) in MID_CONVERSATION_SYSTEM_MODELS else "user"
+        return MessageParam(role=role, content=[TextBlockParam(type="text", text=live)])  # type: ignore[typeddict-item]  # role is a Literal union the API accepts
 
     async def _stream_message(self, messages: list[MessageParam], *, disable_tools: bool = False) -> Message:
         """Stream one response, emitting each text delta to the listener; return the assembled message.
@@ -279,6 +302,9 @@ class Agent:
             self._turn_budget_message(turn_number, force_answer=force_answer),
             *await self.toolset.user_messages(),
             time_message,
+            # Last, and after a user message: a mid-conversation system message must not open the
+            # list and must be the final entry or be followed by an assistant turn.
+            *([live] if (live := await self._live_context()) else []),
         ]
 
     async def _execute_tools(

--- a/baski/agents/tool.py
+++ b/baski/agents/tool.py
@@ -62,12 +62,20 @@ class Tool(ABC):
             input_schema=self.input_schema,
         )
 
+    #: Set True when `system_prompt()` returns content that CHANGES between turns — a live store
+    #: read, a growing scratchpad. Such content is delivered after the cached prefix instead of
+    #: inside the system prompt: the render order is tools → system → messages, so editing the
+    #: system block invalidates every cached message behind it. Measured on one consumer: a single
+    #: core-memory edit mid-run threw away ~6.7k cached tokens and re-wrote them at the write rate.
+    live_system_prompt: ClassVar[bool] = False
+
     async def system_prompt(self) -> str:
         """Extra instructions this tool adds to the agent system prompt, or "" for none.
 
         Async and re-read every turn (symmetric with `user_message`), so a tool whose guidance
         depends on live state — e.g. owner preferences loaded from a store — can return current
-        content each turn rather than a value frozen at build time.
+        content each turn rather than a value frozen at build time. A tool that actually uses that
+        freedom must also set `live_system_prompt`, or it pays for the whole conversation's cache.
         """
         return ""
 

--- a/baski/agents/toolset.py
+++ b/baski/agents/toolset.py
@@ -51,10 +51,10 @@ class ToolSet:
         self._tools.pop(tool_name, None)
 
     async def system_prompt(self) -> str:
-        """The tool roster plus each tool's own prompt contribution, for the system prompt.
+        """The tool roster plus the prompt contributions that are STABLE across turns.
 
-        Async and aggregated every turn (like `user_messages`), so tools whose guidance is live
-        (e.g. owner preferences from a store) contribute fresh content each turn.
+        Aggregated every turn (like `user_messages`) so a tool can still compute its text, but one
+        that flags `live_system_prompt` is excluded here and delivered by `live_system_prompt()`.
         """
         if not self._tools:
             return "No tools available"
@@ -64,8 +64,22 @@ class ToolSet:
             roster.append(f"{i}. {tool.one_line} ({tool.name})")
 
         sections = ["\n".join(roster)]
-        sections.extend([c for tool in self._tools.values() if (c := await tool.system_prompt())])
+        sections.extend(
+            [c for tool in self._tools.values() if not tool.live_system_prompt and (c := await tool.system_prompt())]
+        )
         return "\n\n".join(sections)
+
+    async def live_system_prompt(self) -> str:
+        """The contributions that CHANGE between turns, kept out of the cached system block.
+
+        Render order is tools → system → messages, so a system prompt differing by one byte
+        invalidates every cached message behind it. Content a tool rewrites as the agent works — a
+        core-memory block it can edit, a scratchpad it appends to — therefore rides after the
+        breakpoint instead, where a change costs only its own tokens.
+        """
+        return "\n\n".join(
+            [c for tool in self._tools.values() if tool.live_system_prompt and (c := await tool.system_prompt())]
+        )
 
     async def user_messages(self) -> list[MessageParam]:
         """Per-turn user blocks every tool injects at the top of the prompt (skip Nones)."""

--- a/tests/test_live_context.py
+++ b/tests/test_live_context.py
@@ -1,0 +1,86 @@
+"""Where a tool's per-turn content is delivered, and why it matters.
+
+Render order is tools → system → messages, so a system prompt that differs by one byte invalidates
+every cached message behind it. Content a tool rewrites while the agent works therefore has to ride
+AFTER the cache breakpoint. Measured on a consumer before this split: one core-memory edit mid-run
+threw away ~6.7k cached tokens and re-wrote them at the write rate, on 12% of multi-turn runs.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from pydantic import BaseModel
+
+from baski.agents.tool import Tool
+from baski.agents.toolset import ToolSet
+
+pytestmark = pytest.mark.asyncio
+
+
+class _Stable(Tool):
+    """A tool whose guidance is a constant — safe inside the cached system block."""
+
+    name = "stable"
+    one_line = "stable guidance"
+    description = "stable"
+
+    class Input(BaseModel):
+        """No arguments."""
+
+    async def execute(self) -> str:
+        return ""
+
+    async def system_prompt(self) -> str:
+        return "STABLE GUIDANCE"
+
+
+class _Live(_Stable):
+    """A tool that rewrites its own guidance as the agent works — e.g. an editable memory block."""
+
+    name = "live"
+    one_line = "live block"
+    live_system_prompt = True
+
+    async def system_prompt(self) -> str:
+        return "LIVE BLOCK"
+
+
+@pytest.fixture
+def toolset() -> ToolSet:
+    ts = ToolSet()
+    ts.add(_Stable())
+    ts.add(_Live())
+    return ts
+
+
+async def test_live_content_is_kept_out_of_the_system_prompt(toolset: ToolSet) -> None:
+    """The whole point: a tool that rewrites itself must not sit in the block the cache keys on."""
+    system = await toolset.system_prompt()
+
+    assert "STABLE GUIDANCE" in system
+    assert "LIVE BLOCK" not in system
+
+
+async def test_live_content_is_still_delivered(toolset: ToolSet) -> None:
+    """Excluding it from the system prompt must not drop it — that would silently lose the agent's
+    core memory rather than merely re-cache it."""
+    assert await toolset.live_system_prompt() == "LIVE BLOCK"
+
+
+async def test_a_toolset_with_nothing_live_produces_no_trailing_block(toolset: ToolSet) -> None:
+    """An empty string means the Agent appends no message at all; a blank one would cost tokens and
+    push a stray empty turn into every request."""
+    only_stable = ToolSet()
+    only_stable.add(_Stable())
+
+    assert await only_stable.live_system_prompt() == ""
+
+
+async def test_the_roster_still_lists_every_tool(toolset: ToolSet) -> None:
+    """Routing a tool's guidance elsewhere must not hide the tool itself — the model still has to
+    know it can be called."""
+    system = await toolset.system_prompt()
+
+    assert "(stable)" in system
+    assert "(live)" in system


### PR DESCRIPTION
Живое содержимое инструментов уезжает из системного промпта за кэш-брейкпоинт.

## Что мерили

Порядок рендера — `tools` → `system` → `messages`. Значит системный промпт, отличающийся на один байт, инвалидирует **всю** историю сообщений за собой. При этом `Tool.system_prompt()` перечитывается каждый турн ровно затем, чтобы содержимое могло быть живым — и инструмент, который этой свободой пользовался, каждый раз платил кэшем всего разговора.

Из прод-трейсов потребителя, один прогон:

```
read=0      write=6736
read=6736   write=1422
read=8158   write=1043
read=3560   write=6337   ← префикс схлопнулся с 8158 до 3560
read=3560   write=8126   ← и переписывается заново
```

3560 — это блок `tools`, единственное, что рендерится **до** `system`. Несохранённого входа при этом 292 токена: переписывалось то, что могло читаться в десять раз дешевле.

На 60 прогонах: **12% многотурновых теряют префикс на середине**, 85 063 лишних токен-эквивалента.

## Что меняется

Инструмент объявляет `live_system_prompt = True`, если его вклад меняется между турнами. Такие вклады исключаются из кэшируемого системного блока и доставляются хвостовым сообщением — после брейкпоинта истории, где изменение стоит только собственных токенов.

Дефолт `False`, поэтому инструмент, возвращающий константу, ведёт себя ровно как раньше.

## Про роль хвостового сообщения

Используется роль `system` там, где модель принимает её в середине диалога: это операторский канал, и он не трогает кэш истории. Где не принимает — падает на user-блок, который кэшируется так же и отличается только авторитетом.

Список моделей явный, а не сравнение версий: **Sonnet 5 эту роль отвергает**, хотя новее Opus 4.8, который принимает.

Размещение удовлетворяет правилу API для этой роли: последним в списке, после user-сообщения, никогда первым.

## Проверено

Обратной мутацией: возвращаю живое содержимое в системный промпт — тест на разделение краснеет. `make lint`, `make typecheck`, `make test` — 63 теста.

## Дальше

Потребитель помечает свои волатильные инструменты (у nisse это блок core memory и дерево гипотез) — одна строка на каждый.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PWRbL7sRe2F5xJh7xt68y5
