### PR TITLE
fix(trace): created_at — дата, а не текст, похожий на дату

### DIFF
--- a/baski/agents/trace.py
+++ b/baski/agents/trace.py
@@ -162,7 +162,7 @@ class TraceCollector:
         self._turns: list[TurnRecord] = []
         self._result: AgentExecuteResult | None = None
         self._error: str | None = None
-        self._created_at = datetime.now().isoformat()
+        self._created_at = datetime.now()  # a real datetime: Mongo stores and compares it as one
         self._current_turn: TurnRecord | None = None
         self._turn_start: float = 0
         self._persist_task: asyncio.Task | None = None
@@ -269,7 +269,7 @@ class TraceCollector:
         """Assemble the full trace record — the single source for both persist modes."""
         return TraceRecord(
             id=self.id,
-            created_at=self._created_at,
+            created_at=self._created_at.isoformat(),  # the GCS record is JSON; there it is a string
             user_request=self._user_request,
             model=self._model,
             system_prompt=self._system_prompt,
@@ -345,6 +345,12 @@ class TraceCollector:
         this agent's own calls, so a query may sum rows without counting a child twice.
 
         `tools` is the per-tool line of the same question — see `ToolUsageRecord`.
+
+        `created_at` goes in as a datetime, not its `isoformat()`. As a string it carried the
+        WRITER's offset (`primitives.datetime.now` is local time), so rows from a server reading
+        `+00:00` and rows from a laptop reading `-07:00` sorted against each other by their text —
+        and a window query silently lost the ones whose offset ordered them wrong. A date is not a
+        string; every other timestamp in these databases is stored tz-aware for exactly this reason.
         """
         doc = {
             "_id": self.id,

--- a/tests/agents/test_trace_created_at.py
+++ b/tests/agents/test_trace_created_at.py
@@ -1,0 +1,40 @@
+"""A trace's timestamp must go into Mongo as a date, and into the GCS record as a string.
+
+Stored as a string it carried the writer's UTC offset, so rows from a server (`+00:00`) and rows
+from a laptop (`-07:00`) compared against each other by their text. A window query then dropped the
+ones whose offset ordered them wrong — silently, since the rows are still there.
+"""
+
+import datetime as dt
+from typing import cast
+
+from pymongo.asynchronous.database import AsyncDatabase
+
+from baski.agents.trace import TraceCollector, TraceCollectorConfig
+
+
+def _collector() -> TraceCollector:
+    return TraceCollector(
+        config=TraceCollectorConfig(
+            user_request="anything",
+            model="claude-opus-5",
+            agent_name="assistant",
+            system_prompt="",
+            bucket_name="unused",
+            database=cast("AsyncDatabase", None),
+        )
+    )
+
+
+def test_the_timestamp_is_a_timezone_aware_datetime() -> None:
+    created = _collector()._created_at
+
+    assert isinstance(created, dt.datetime)
+    assert created.tzinfo is not None, "a naive datetime compares wrong the moment two writers differ"
+
+
+def test_two_collectors_in_different_zones_still_order_by_the_instant() -> None:
+    earlier = _collector()._created_at.astimezone(dt.UTC)
+    later = _collector()._created_at.astimezone(dt.timezone(dt.timedelta(hours=-7)))
+
+    assert earlier <= later, "ordering must follow the instant, not the text of the offset"


### PR DESCRIPTION
`traces` — единственная коллекция, которая писала свою метку времени строкой:

```python
self._created_at = datetime.now().isoformat()
```

Все остальные метки времени в этих базах — tz-aware даты. А эта была текстом, несущим смещение **того, кто её записал**: `primitives.datetime.now` возвращает локальное время, поэтому сервер пишет `+00:00`, а ноутбук — `-07:00`.

Две строки, записанные с разницей в секунду, начинают сравниваться **по тексту, а не по моменту**, и запрос по окну выбрасывает те, чьи смещения упорядочили их не так. Молча: строки в коллекции лежат, в ответе их просто нет, и в ответе ничего об этом не сказано.

Это не гипотеза — на этом споткнулся отчёт `make cost` в nisse, и починен он был сначала обходом в потребителе. Обход убирается вместе с причиной.

Mongo принимает datetime и сравнивает его как дату. Запись в GCS остаётся JSON, поэтому там метка форматируется в строку **на границе**, а не является строкой на всём пути.

Строки, записанные раньше, несут старый текст и под запрос с датой больше не попадают. Это прогоны времён до появления полей расходов — разложить их по статьям всё равно было нечем.

## Тесты

| что закрыто | как краснеет на старом коде |
|---|---|
| метка времени — tz-aware datetime | была строкой |
| порядок следует моменту, а не тексту смещения | `-07:00` сортировался как текст |

75 тестов, lint и mypy зелёные.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
