### PR TITLE
feat(pricing): цену называет тот, кто выбрал модель

### DIFF
--- a/baski/agents/agent.py
+++ b/baski/agents/agent.py
@@ -17,7 +17,7 @@ from .events import Message as MessageEvent
 from .execute_result import AgentExecuteResult
 from .judge import Judge, JudgeUnavailableError, Verdict, retry_prompt
 from .message_history import EPHEMERAL_CACHE, MessageHistory
-from .pricing import ExecutionStats
+from .pricing import ExecutionStats, ModelPrice
 from .toolset import ToolSet
 from .trace import TraceCollector, TraceCollectorConfig
 
@@ -110,6 +110,11 @@ class AgentConfig(NamedTuple):
     # spent the money, and a default would fill the column with one name that is right for some rows
     # and silently wrong for the rest — unfalsifiable afterwards. The caller knows; let it say.
     name: str
+    # What the model costs, per billed bucket. Required and supplied by the caller, because the
+    # caller is who picked the model: a table lookup here can only price models this library knows,
+    # and an agent may legitimately run on one behind a gateway that it never will. Anthropic's own
+    # rates are in `MODEL_PRICING` for callers that want them.
+    price: ModelPrice
     model: str = DEFAULT_MODEL
     await_trace: bool = False  # block reply on trace persistence (tests/probe read it right after)
     local_traces_dir: str | None = None  # write full traces here instead of GCS (tests/probe); None → GCS
@@ -142,6 +147,7 @@ class Agent:
         self._judge_max_retries = config.judge_max_retries
         self._max_turns = config.max_turns
         self._name = config.name
+        self._price = config.price
         self.on_event = on_event
         # Not in message_history.turns, so truncate/prune_transcript can't reach it.
         self._pinned: list[MessageParam] = []
@@ -423,7 +429,7 @@ class Agent:
         label = self._request_label()
         logger.info("Agent execution started", extra={"userRequest": label[:100]})
 
-        stats = ExecutionStats(model=str(self.params["model"]))
+        stats = ExecutionStats(model=str(self.params["model"]), price=self._price)
         trace = TraceCollector(
             config=TraceCollectorConfig(
                 user_request=label,

--- a/baski/agents/pricing.py
+++ b/baski/agents/pricing.py
@@ -1,47 +1,53 @@
-"""Anthropic API pricing for cost calculation."""
+"""What a model costs, and the running tally of what one execution spent."""
 
 from dataclasses import dataclass
+from typing import NamedTuple
 
 from anthropic.types import Usage
 from pydantic import BaseModel
 
-# Pricing in USD per million tokens
-# Source: https://www.anthropic.com/pricing
-MODEL_PRICING = {
-    "claude-opus-5": {
-        "input": 5.00,  # $5 per million input tokens
-        "output": 25.00,  # $25 per million output tokens
-    },
-    "claude-sonnet-5": {
-        "input": 3.00,  # $3 per million input tokens
-        "output": 15.00,  # $15 per million output tokens
-    },
-    "claude-opus-4-8": {
-        "input": 5.00,  # $5 per million input tokens
-        "output": 25.00,  # $25 per million output tokens
-    },
-    "claude-opus-4-6": {
-        "input": 5.00,  # $5 per million input tokens
-        "output": 25.00,  # $25 per million output tokens
-    },
-    "claude-opus-4-5": {
-        "input": 5.00,  # $5 per million input tokens
-        "output": 25.00,  # $25 per million output tokens
-    },
-    "claude-sonnet-4-5": {
-        "input": 3.00,  # $3 per million input tokens
-        "output": 15.00,  # $15 per million output tokens
-    },
-    "claude-haiku-4-5": {
-        "input": 1.00,  # $1 per million input tokens
-        "output": 5.00,  # $5 per million output tokens
-    },
-}
+
+class ModelPrice(NamedTuple):
+    """USD per million tokens, one rate per billed bucket.
+
+    Four explicit rates rather than multipliers off `input`, because the multipliers are Anthropic's
+    and nobody else's: an open model served through a gateway may bill a cached read at 0.30x
+    (moonshotai/kimi-k2-thinking) or not bill it at all (openai/gpt-oss-120b, zai/glm-4.7-flash),
+    and none of them charge a premium to write the cache. Deriving those from `input` understated one
+    measured run threefold.
+    """
+
+    input: float
+    output: float
+    cache_write: float
+    cache_read: float
 
 
-# Cache multipliers vs base input price (5-minute ephemeral write, read).
+# Anthropic's 5-minute ephemeral cache: a written token costs 1.25x base input, a read one 0.10x.
 _CACHE_WRITE_MULTIPLIER = 1.25
 _CACHE_READ_MULTIPLIER = 0.10
+
+
+def anthropic_price(base_input: float, output: float) -> ModelPrice:
+    """An Anthropic model's four rates, derived from the two the price list publishes."""
+    return ModelPrice(
+        input=base_input,
+        output=output,
+        cache_write=base_input * _CACHE_WRITE_MULTIPLIER,
+        cache_read=base_input * _CACHE_READ_MULTIPLIER,
+    )
+
+
+# Source: https://www.anthropic.com/pricing
+MODEL_PRICING: dict[str, ModelPrice] = {
+    "claude-opus-5": anthropic_price(5.00, 25.00),
+    "claude-sonnet-5": anthropic_price(3.00, 15.00),
+    "claude-opus-4-8": anthropic_price(5.00, 25.00),
+    "claude-opus-4-6": anthropic_price(5.00, 25.00),
+    "claude-opus-4-5": anthropic_price(5.00, 25.00),
+    "claude-sonnet-4-5": anthropic_price(3.00, 15.00),
+    "claude-haiku-4-5": anthropic_price(1.00, 5.00),
+}
 
 
 def effective_input_tokens(usage: Usage) -> int:
@@ -49,24 +55,19 @@ def effective_input_tokens(usage: Usage) -> int:
     return usage.input_tokens + (usage.cache_read_input_tokens or 0) + (usage.cache_creation_input_tokens or 0)
 
 
-def calculate_cost(model: str, usage: Usage) -> float:
-    """Calculate cost in USD for one API response, pricing each cache bucket at its own rate.
+def calculate_cost(price: ModelPrice, usage: Usage) -> float:
+    """Cost in USD for one API response, each bucket at its own published rate.
 
-    An unpriced model raises rather than falling back to a default rate: the fallback quietly
-    charged every `claude-opus-5` run at Sonnet's price and understated a month of Opus spend by
-    1.67x, with nothing in the number to show it was a guess. `ExecutionStats` checks the model
-    when it is constructed, so this raises before the first call, not after the bill.
+    Takes the price rather than the model name so a model the table has never heard of — anything
+    behind a gateway — is priced by whoever chose it, instead of being guessed at or rejected. The
+    table stays the convenient source for Anthropic's own models.
     """
-    pricing = MODEL_PRICING[model]
-
-    input_cost = (usage.input_tokens / 1_000_000) * pricing["input"]
-    output_cost = (usage.output_tokens / 1_000_000) * pricing["output"]
-    cache_write_cost = (
-        ((usage.cache_creation_input_tokens or 0) / 1_000_000) * pricing["input"] * _CACHE_WRITE_MULTIPLIER
-    )
-    cache_read_cost = ((usage.cache_read_input_tokens or 0) / 1_000_000) * pricing["input"] * _CACHE_READ_MULTIPLIER
-
-    return input_cost + output_cost + cache_write_cost + cache_read_cost
+    return (
+        usage.input_tokens * price.input
+        + usage.output_tokens * price.output
+        + (usage.cache_creation_input_tokens or 0) * price.cache_write
+        + (usage.cache_read_input_tokens or 0) * price.cache_read
+    ) / 1_000_000
 
 
 class ExecutionLogFields(BaseModel):
@@ -84,7 +85,8 @@ class ExecutionLogFields(BaseModel):
 class ExecutionStats:
     """Tracks token usage, costs, and turn counts across an agent execution."""
 
-    model: str
+    model: str  # recorded on the trace, so a stored run says WHAT was called
+    price: ModelPrice  # and at what rate — supplied by whoever chose the model, not looked up here
     input_tokens: int = 0
     output_tokens: int = 0
     # The two cache buckets, kept apart because they are priced 12.5x apart: a written token costs
@@ -98,11 +100,6 @@ class ExecutionStats:
     cost: float = 0.0  # this run and everything it delegated to — what the answer cost in total
     own_cost: float = 0.0  # only this agent's own API calls, so rows from many agents can be summed
 
-    def __post_init__(self) -> None:
-        """Reject an unpriced model now, before the run spends anything on it."""
-        if self.model not in MODEL_PRICING:
-            raise KeyError(f"No pricing for model {self.model!r} — add it to MODEL_PRICING")
-
     def collect(self, usage: Usage) -> None:
         """Accumulate token usage and cost from a single API response.
 
@@ -115,7 +112,7 @@ class ExecutionStats:
         self.cache_write_tokens += usage.cache_creation_input_tokens or 0
         self.last_input_tokens = effective_input_tokens(usage)
         self.turn_count += 1
-        call_cost = calculate_cost(self.model, usage)
+        call_cost = calculate_cost(self.price, usage)
         self.cost += call_cost
         self.own_cost += call_cost
 

--- a/tests/agents/test_pricing.py
+++ b/tests/agents/test_pricing.py
@@ -1,26 +1,26 @@
-"""A run must be billed at its own model's rate, and an unpriced model must say so.
+"""A run must be billed at its own model's rate, and every bucket at that model's own rate.
 
-The regression these guard: `MODEL_PRICING.get(model, MODEL_PRICING["claude-sonnet-4-5"])` charged
-every `claude-opus-5` run at Sonnet's price. Nothing failed and nothing looked wrong — a month of
-production spend simply read 1.67x low in the cost line under every answer.
+Two regressions these guard. `MODEL_PRICING.get(model, MODEL_PRICING["claude-sonnet-4-5"])` charged
+every `claude-opus-5` run at Sonnet's price — nothing failed, a month of production spend simply read
+1.67x low. And deriving the cache rates from `input` by Anthropic's 1.25x/0.10x multipliers priced one
+measured gateway run at 3.04x what the provider actually charged: an open model may bill a cached read
+at 0.30x of input, or not bill it at all.
 """
 
 import pytest
 from anthropic.types import Usage
 
-from baski.agents.pricing import ExecutionStats, calculate_cost
+from baski.agents.pricing import MODEL_PRICING, ExecutionStats, ModelPrice, anthropic_price, calculate_cost
+
+# openai/gpt-oss-120b as the Vercel catalogue prices it: cached reads are not billed at all.
+_GATEWAY = ModelPrice(input=0.10, output=0.50, cache_write=0.0, cache_read=0.0)
 
 
 def test_opus_is_not_billed_at_sonnet_rates() -> None:
     usage = Usage(input_tokens=1_000_000, output_tokens=1_000_000)
 
-    assert calculate_cost("claude-opus-5", usage) == pytest.approx(30.0)  # $5 in + $25 out
-    assert calculate_cost("claude-sonnet-5", usage) == pytest.approx(18.0)  # $3 in + $15 out
-
-
-def test_an_unpriced_model_raises_instead_of_guessing() -> None:
-    with pytest.raises(KeyError, match="claude-not-a-model"):
-        ExecutionStats(model="claude-not-a-model")
+    assert calculate_cost(MODEL_PRICING["claude-opus-5"], usage) == pytest.approx(30.0)  # $5 in + $25 out
+    assert calculate_cost(MODEL_PRICING["claude-sonnet-5"], usage) == pytest.approx(18.0)  # $3 in + $15 out
 
 
 def test_each_cache_bucket_is_priced_at_its_own_rate() -> None:
@@ -29,11 +29,19 @@ def test_each_cache_bucket_is_priced_at_its_own_rate() -> None:
     )
 
     # $5 base: a written token costs 1.25x it, a read one 0.10x
-    assert calculate_cost("claude-opus-5", usage) == pytest.approx(6.25 + 0.50)
+    assert calculate_cost(anthropic_price(5.00, 25.00), usage) == pytest.approx(6.25 + 0.50)
+
+
+def test_a_model_that_does_not_bill_cache_reads_is_not_charged_for_them() -> None:
+    """The failure this replaces: charging a gateway's cached reads at 0.10x of input, three times over."""
+    usage = Usage(input_tokens=4_665, output_tokens=2_782, cache_read_input_tokens=37_952)
+
+    charged = 0.001857  # what the gateway's own balance actually moved by for this run
+    assert calculate_cost(_GATEWAY, usage) == pytest.approx(charged, abs=1e-6)
 
 
 def test_stats_keep_the_cache_buckets_and_separate_own_from_delegated_spend() -> None:
-    stats = ExecutionStats(model="claude-opus-5")
+    stats = ExecutionStats(model="claude-opus-5", price=MODEL_PRICING["claude-opus-5"])
 
     stats.collect(Usage(input_tokens=10, output_tokens=20, cache_read_input_tokens=30, cache_creation_input_tokens=40))
     own = stats.own_cost


### PR DESCRIPTION
Нужно, чтобы агент мог работать на модели, о которой библиотека никогда не слышала — на любой из-за шлюза. Сегодня это невозможно дважды: поиск в таблице падает на незнакомом имени, а две кэш-ставки выводятся из входной по множителям 1.25× и 0.10×, которые принадлежат Anthropic и больше никому.

## Почему множители не годятся

Сверено с тем, что провайдер **фактически списал** (баланс шлюза до и после одного прогона):

| модель | ставка на чтение кэша | что дают множители |
|---|---|---|
| `openai/gpt-oss-120b` | **не тарифицируется** | 0.10 × входа |
| `zai/glm-4.7-flash` | **не тарифицируется** | 0.10 × входа |
| `moonshotai/kimi-k2-thinking` | **0.30 × входа** | 0.10 × входа |

Выведенные ставки оценили один прогон в **3.04 раза** дороже реального списания. Ни один из этих случаев не выражается множителем, который библиотека может знать заранее.

## Что изменено

`ModelPrice` несёт четыре явные ставки — вход, выход, запись кэша, чтение кэша. `AgentConfig` требует её обязательно: **цену называет тот, кто выбрал модель.** Это тот же ход, что уже сделан для `AgentConfig.name`, и по той же причине — библиотека знать не может, а значение, которое она придумает, будет неверным так, что потом этого никто не увидит.

`MODEL_PRICING` остаётся удобным источником Anthropic-ставок, теперь типизированным: `anthropic_price(5.00, 25.00)` выводит четвёрку из двух чисел прейскуранта.

`ExecutionStats` больше не отвергает незнакомую модель — состояние «модель без цены» стало невыразимым: цена это обязательный аргумент, а не поиск, который может промахнуться.

## Тесты

78 зелёных. Добавлен один новый: прогон `gpt-oss` с 37 952 токенами чтения кэша должен стоить ровно $0.001857 — это не расчёт, а число, на которое сдвинулся баланс шлюза.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TsDY2sCSfY6MTfUqFkMKeC
