### PR TITLE
feat(browse): читать PDF, а не падать на нём

### DIFF
--- a/baski/clients/playwright_client.py
+++ b/baski/clients/playwright_client.py
@@ -1,6 +1,7 @@
 """Async Playwright client that fetches pages and converts them to cleaned markdown."""
 
 import asyncio
+import io
 import logging
 from datetime import UTC
 from datetime import datetime as _dt
@@ -8,6 +9,7 @@ from http import HTTPStatus
 from pathlib import Path
 from typing import Any, Self, cast
 
+import httpx
 import trafilatura
 from anyio import Path as AsyncPath
 from bs4 import BeautifulSoup
@@ -18,6 +20,7 @@ from markdownify import markdownify as md
 from playwright.async_api import Browser, BrowserContext, Page, Playwright, StorageState, async_playwright
 from playwright.async_api import Error as PlaywrightError
 from playwright.async_api import TimeoutError as PlaywrightTimeoutError
+from pypdf import PdfReader
 
 __all__ = ["PlaywrightClient"]
 
@@ -159,6 +162,12 @@ class PlaywrightClient:
         try:
             await self._safe_goto(page, url)
             html_content = await page.content()
+        except PlaywrightError as e:
+            if _DOWNLOAD_MARKER not in str(e):
+                await self._dump_error_context(page, url, e)
+                raise
+            logger.info("Url serves a document, not a page", extra={"url": url})
+            return await _fetch_document(url)
         except Exception as e:
             await self._dump_error_context(page, url, e)
             raise
@@ -242,6 +251,46 @@ class PlaywrightClient:
             )
         except Exception as e:  # noqa: BLE001 — debug dump must not crash the main error handler
             logger.info("Failed to dump error context", extra={"error": str(e)})
+
+
+# Chromium answers a url that serves a file — a PDF, a CSV — by starting a download instead of
+# rendering, and reports it as this error. Measured over 663 recorded runs: 51 of the 93 browse
+# failures were exactly this, 44 of them ending in `.pdf`, and the hosts were the authoritative ones
+# — cdtfa.ca.gov, chp.ca.gov, Stanford, BYU, NORC. The agent was losing primary sources and falling
+# back to second-hand pages, or to inventing the number.
+_DOWNLOAD_MARKER = "Download is starting"
+_PDF_MAGIC = b"%PDF-"
+_DOCUMENT_TIMEOUT = 60.0
+
+
+async def _fetch_document(url: str) -> str:
+    """Download what the browser refused to render, and return its text.
+
+    Only PDFs are decoded; anything else comes back as text if it is text, and raises otherwise. The
+    point is to stop losing the source, not to become a file converter.
+    """
+    async with httpx.AsyncClient(follow_redirects=True, headers={"user-agent": _SAFARI_UA}) as client:
+        response = await client.get(url, timeout=_DOCUMENT_TIMEOUT)
+        response.raise_for_status()
+    body = response.content
+    if body.startswith(_PDF_MAGIC):
+        return await asyncio.to_thread(_pdf_to_text, body, url)
+    if response.headers.get("content-type", "").startswith("text/"):
+        return response.text
+    raise ValueError(f"{url} serves {response.headers.get('content-type', 'an unknown type')}, which is not readable")
+
+
+def _pdf_to_text(body: bytes, url: str) -> str:
+    """Page text, one blank line between pages, so a citation can name the page it came from."""
+    reader = PdfReader(io.BytesIO(body))
+    pages = [page.extract_text() or "" for page in reader.pages]
+    text = "\n\n".join(
+        f"[page {number}]\n{content.strip()}" for number, content in enumerate(pages, 1) if content.strip()
+    )
+    if not text:
+        # A scanned PDF is images; saying so beats handing the agent an empty page it will fill in itself.
+        raise ValueError(f"{url} is a PDF with no extractable text ({len(pages)} pages — likely scanned images)")
+    return text
 
 
 _NAV_SELECTORS = (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ dependencies = [
     "aiogram>=3",
     "marshmallow>=3",
     "playwright",
+    "pypdf",  # browse_website: a url that serves a document, not a page — Chromium cannot render one
     "beautifulsoup4",
     "markdownify",
     "pulumi",

--- a/tests/clients/test_pdf_documents.py
+++ b/tests/clients/test_pdf_documents.py
@@ -1,0 +1,93 @@
+"""A url that serves a document must come back as text, not as a failure.
+
+Measured over 663 recorded runs: 51 of 93 browse failures were Chromium refusing to render a file,
+44 of them `.pdf`, and the hosts were the primary sources — cdtfa.ca.gov, chp.ca.gov, Stanford, BYU.
+Every one was a source the agent asked for and never got, which is where it fell back to a
+second-hand page or invented the number.
+
+What is tested here is the decision — when to stop treating a url as a page — not pypdf's extraction,
+which is the library's own business.
+"""
+
+import io
+
+import pytest
+from playwright.async_api import Error as PlaywrightError
+from pypdf import PdfWriter
+
+from baski.clients.playwright_client import PlaywrightClient, _fetch_document, _pdf_to_text
+
+
+def _blank_pdf() -> bytes:
+    """A real PDF whose page carries no text — what a scan looks like to an extractor."""
+    writer = PdfWriter()
+    writer.add_blank_page(width=200, height=200)
+    buffer = io.BytesIO()
+    writer.write(buffer)
+    return buffer.getvalue()
+
+
+def test_a_pdf_with_no_text_says_so_instead_of_returning_nothing() -> None:
+    """A scanned PDF is images. An empty string would be filled in by the agent's imagination."""
+    with pytest.raises(ValueError, match="no extractable text"):
+        _pdf_to_text(_blank_pdf(), "https://example.test/scan.pdf")
+
+
+@pytest.mark.asyncio
+async def test_a_non_document_type_is_refused_rather_than_guessed(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An image is not readable; saying so beats handing the agent bytes as if they were prose."""
+
+    class _Response:
+        content = b"\x89PNG\r\n"
+        headers = {"content-type": "image/png"}
+        text = ""
+
+        def raise_for_status(self) -> None:
+            """The server answered fine; the TYPE is the problem."""
+
+    class _Client:
+        async def __aenter__(self) -> "_Client":
+            return self
+
+        async def __aexit__(self, *_: object) -> None:
+            return None
+
+        async def get(self, *_: object, **__: object) -> _Response:
+            return _Response()
+
+    monkeypatch.setattr("baski.clients.playwright_client.httpx.AsyncClient", lambda **_: _Client())
+    with pytest.raises(ValueError, match="not readable"):
+        await _fetch_document("https://example.test/x.png")
+
+
+@pytest.mark.asyncio
+async def test_a_download_is_fetched_instead_of_reported_as_a_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The whole point: `Download is starting` stops being an error and becomes a fetch."""
+    fetched: list[str] = []
+
+    async def _document(url: str) -> str:
+        fetched.append(url)
+        return "[page 1]\nthe rate is 9.375%"
+
+    class _Page:
+        async def goto(self, *_: object, **__: object) -> None:
+            raise PlaywrightError("Page.goto: Download is starting")
+
+        async def content(self) -> str:
+            return ""
+
+        async def close(self) -> None:
+            return None
+
+    class _Context:
+        async def new_page(self) -> _Page:
+            return _Page()
+
+    monkeypatch.setattr("baski.clients.playwright_client._fetch_document", _document)
+    client = PlaywrightClient()
+    client._context = _Context()  # type: ignore[assignment]  # noqa: SLF001 — no seam to inject a context
+
+    text = await client.fetch_page_markdown("https://cdtfa.ca.gov/rates.pdf")
+
+    assert text == "[page 1]\nthe rate is 9.375%"
+    assert fetched == ["https://cdtfa.ca.gov/rates.pdf"]

--- a/uv.lock
+++ b/uv.lock
@@ -280,6 +280,7 @@ dependencies = [
     { name = "pulumi-gcp" },
     { name = "pydantic" },
     { name = "pymongo" },
+    { name = "pypdf" },
     { name = "python-dateutil" },
     { name = "pytz" },
     { name = "pyyaml" },
@@ -324,6 +325,7 @@ requires-dist = [
     { name = "pulumi-gcp" },
     { name = "pydantic" },
     { name = "pymongo", specifier = ">=4.9" },
+    { name = "pypdf" },
     { name = "python-dateutil" },
     { name = "pytz" },
     { name = "pyyaml" },
@@ -2318,6 +2320,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/9e/d8/b75f6f4ab6c8beb50b0270a4f1e2530b5774f5e116563440e1677ca1820f/pymongo-4.17.0-cp314-cp314t-win32.whl", hash = "sha256:b93b22eedc62598cf5ee9d8c8007a8e9121c50fd88137012d8985500e9dc3151", size = 1056356, upload-time = "2026-04-20T16:39:22.996Z" },
     { url = "https://files.pythonhosted.org/packages/e4/5e/648c8a238eef18a25ed8a169ea6542d4a860bbec3e95b3d9badac2935c71/pymongo-4.17.0-cp314-cp314t-win_amd64.whl", hash = "sha256:3689ea34f6b647c7d1e7bdc60fcfb214b2789ed1359a7fb96569c69f50e5f18f", size = 1090964, upload-time = "2026-04-20T16:39:24.989Z" },
     { url = "https://files.pythonhosted.org/packages/dc/cb/d9780b66939c4fc1f024bcc7be23a2abcfe06a9745ca8fa76dc73395482e/pymongo-4.17.0-cp314-cp314t-win_arm64.whl", hash = "sha256:9543d8f84c2e5608565c08ac679774811e6730770d8a645439b073422a4276fb", size = 1058526, upload-time = "2026-04-20T16:39:27.924Z" },
+]
+
+[[package]]
+name = "pypdf"
+version = "6.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/17/17/ee75a92718ec7212de831e71454d702225aa5e474a805cce169806044453/pypdf-6.15.0.tar.gz", hash = "sha256:d39c4d955a76409284a905e2d65b40076d77ab76129e0faaeeb6612403ecfc79", size = 6993794, upload-time = "2026-08-06T13:06:49.929Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/af/72/ce3067ac31e214a66388159f8462ddb8c13dd00170f24d555a1f1ae8ee91/pypdf-6.15.0-py3-none-any.whl", hash = "sha256:14e001d6504822cb1ca9c7ed9a69bccb320f59b320730f55af804361abe4d5ee", size = 378123, upload-time = "2026-08-06T13:06:47.709Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Агент чаще всего спотыкался не на сложных страницах, а на **PDF** — и это были лучшие источники, какие он находил.

## Что было

Chromium не рендерит файл: на ссылку, отдающую документ, он начинает скачивание и возвращает ошибку `Page.goto: Download is starting`. Она уходила наверх как отказ инструмента.

Замер по 663 сохранённым прогонам:

```
93 отказа browse_website
├── 51  (55%)  «Download is starting»   ← файл, а не страница
│     └── 44 из них заканчиваются на .pdf, остальные семь — тоже документы
│         (CSV с FRED, viewcontent.cgi университетских репозиториев)
├── 24  (26%)  таймауты
├── 10  (11%)  DNS не разрешается
└──  8   (9%)  обрыв соединения
```

Хосты говорят сами за себя: `cdtfa.ca.gov`, `www.chp.ca.gov`, Stanford, BYU, SMU, NORC.

## Почему это дорого стоило

```
агент ищет факт
   │
   ├── находит первоисточник (PDF закона / инструкции / исследования)
   │      └── browse_website → ОТКАЗ ────┐
   │                                     │
   └── остаётся с пересказами        ────┴──> либо второисточник,
       из выдачи поиска                       либо выдуманное число
```

Проверки фактов вслепую в этой же сессии нашли обе ветки на живых ответах: цитату в кавычках, приписанную инструкции к форме 1065, которой в документе нет, и «оценку по индустрии» вместо цены, напечатанной на недоступной странице.

## Что сделано

```
fetch_page_markdown(url)
   │
   ├── Chromium рендерит  ──> trafilatura ──> markdown          (как было)
   │
   └── «Download is starting»
          └── httpx GET ──┬── %PDF-  ──> pypdf ──> «[page N]» + текст
                          ├── text/* ──> как есть
                          └── иначе  ──> явный отказ с названием типа
```

Три решения, которые я принял сам:

**Только PDF декодируется.** Текст отдаётся как есть, всё прочее — явный отказ с указанием типа. Цель — перестать терять источник, а не стать конвертером файлов.

**Номера страниц сохраняются** (`[page 1]`, `[page 2]`). Утверждение из 40-страничного документа должно уметь назвать страницу, иначе цитата непроверяема — ровно та проблема, которую мы чинили правилом цитирования.

**Скан отвечает ошибкой, а не пустотой.** PDF без извлекаемого текста — это картинки; пустая строка была бы дополнена воображением модели.

## Тесты

81 зелёный. Три новых проверяют **решение**, а не извлечение (это забота pypdf): скачивание уходит в загрузчик вместо отказа, скан говорит о себе, нечитаемый тип отвергается.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TsDY2sCSfY6MTfUqFkMKeC
