### PR TITLE
feat(judge): присяжные вместо обёртки одного судьи другим

### DIFF
--- a/baski/agents/__init__.py
+++ b/baski/agents/__init__.py
@@ -16,7 +16,7 @@ from .events import (
     noop,
 )
 from .execute_result import AgentExecuteResult
-from .judge import DEFAULT_JUDGE_MODEL, GeminiJudge, Judge, Verdict
+from .judge import DEFAULT_JUDGE_MODEL, GeminiJudge, Judge, Jury, Verdict
 from .message_history import InMemoryMessageHistory, MessageHistory
 from .tool import Tool, ToolResult
 from .toolset import ToolSet
@@ -36,6 +36,7 @@ __all__ = [
     "InMemoryMessageHistory",
     "Judge",
     "Judged",
+    "Jury",
     "Listener",
     "Message",
     "MessageHistory",

--- a/baski/agents/judge.py
+++ b/baski/agents/judge.py
@@ -6,6 +6,7 @@ blind spots, so it catches completion failures the executor is prone to wave thr
 COMPLETENESS of the deliverable, not factual truth (transcript-checkable without domain knowledge).
 """
 
+import asyncio
 import logging
 from http import HTTPStatus
 from typing import Protocol
@@ -98,6 +99,44 @@ class Verdict(BaseModel):
         description="A direct, imperative instruction telling the assistant what to do next to finish. "
         "Empty when finished. Same language as the user request."
     )
+
+
+class Jury:
+    """Several judges on one answer; it passes only if every one of them passes.
+
+    An agent usually has more than one reason to send an answer back, and those reasons are not the
+    same kind of thing: completeness is a model's judgement, while "did it cite a page it never
+    opened" is arithmetic over the run's own tool calls. Wrapping one judge in another hides which is
+    which and fixes the order at the definition; a jury names the whole panel where it is assembled.
+
+    Judges run concurrently — they do not read each other's verdicts, and one of them is usually a
+    model call worth not waiting for twice.
+
+    Lifecycle: as long-lived as the judges it holds.
+    """
+
+    def __init__(self, judges: list["Judge"]) -> None:
+        """Take the panel. Empty is a caller bug, not a jury that passes everything."""
+        if not judges:
+            raise ValueError("A jury needs at least one judge")
+        self._judges = judges
+
+    async def evaluate(self, transcript: str, answer: str, rules: str) -> Verdict:
+        """One verdict from all of them: finished only if none objects, with every objection kept.
+
+        A `JudgeUnavailableError` from any member propagates, so the loop's existing fail-open path
+        decides — an outage in one grader must not read as that grader's approval.
+        """
+        verdicts = await asyncio.gather(
+            *(judge.evaluate(transcript=transcript, answer=answer, rules=rules) for judge in self._judges)
+        )
+        missing = [gap for verdict in verdicts for gap in verdict.missing]
+        feedback = [verdict.feedback for verdict in verdicts if verdict.feedback]
+        return Verdict(
+            finished=all(verdict.finished for verdict in verdicts),
+            missing=missing,
+            feedback="\n".join(feedback),
+        )
 
 
 class Judge(Protocol):

--- a/tests/agents/test_jury.py
+++ b/tests/agents/test_jury.py
@@ -1,0 +1,74 @@
+"""A panel of judges, not one judge wearing another as a coat.
+
+An agent has more than one reason to send an answer back, and they are different kinds of thing: a
+model's judgement of completeness, and arithmetic over the run's own tool calls. Composition has to
+be visible where the panel is assembled, not buried in a decorator.
+"""
+
+import pytest
+
+from baski.agents.judge import Judge, JudgeUnavailableError, Jury, Verdict
+
+
+class _Says(Judge):
+    """A judge with a fixed opinion."""
+
+    def __init__(self, *, finished: bool, missing: str = "", feedback: str = "") -> None:
+        self._verdict = Verdict(finished=finished, missing=[missing] if missing else [], feedback=feedback)
+
+    async def evaluate(self, transcript: str, answer: str, rules: str) -> Verdict:
+        """Return the opinion it was built with."""
+        return self._verdict
+
+
+class _Unavailable(Judge):
+    """A judge that is down, which is not the same as a judge that approves."""
+
+    async def evaluate(self, transcript: str, answer: str, rules: str) -> Verdict:
+        """Fail the way a quota or a 5xx does."""
+        raise JudgeUnavailableError("quota")
+
+
+async def _verdict(*judges: Judge) -> Verdict:
+    """Run the panel over one answer."""
+    return await Jury(list(judges)).evaluate(transcript="q", answer="a", rules="r")
+
+
+@pytest.mark.asyncio
+async def test_one_objection_is_enough_to_send_the_answer_back() -> None:
+    verdict = await _verdict(_Says(finished=True), _Says(finished=False, missing="cite what you read"))
+
+    assert verdict.finished is False
+
+
+@pytest.mark.asyncio
+async def test_every_objection_is_kept() -> None:
+    """The worker fixes what it is told; a dropped objection is a turn spent on half the problem."""
+    verdict = await _verdict(
+        _Says(finished=False, missing="the county count", feedback="find the CBP figure"),
+        _Says(finished=False, missing="two unopened sources", feedback="open them"),
+    )
+
+    assert verdict.missing == ["the county count", "two unopened sources"]
+    assert verdict.feedback == "find the CBP figure\nopen them"
+
+
+@pytest.mark.asyncio
+async def test_a_unanimous_pass_passes() -> None:
+    verdict = await _verdict(_Says(finished=True), _Says(finished=True))
+
+    assert verdict.finished is True
+    assert verdict.missing == []
+
+
+@pytest.mark.asyncio
+async def test_a_judge_that_is_down_does_not_read_as_approval() -> None:
+    """The loop already decides what to do with an outage; swallowing it here would hide one."""
+    with pytest.raises(JudgeUnavailableError):
+        await _verdict(_Says(finished=True), _Unavailable())
+
+
+def test_an_empty_panel_is_a_caller_bug() -> None:
+    """A jury of nobody would pass every answer — silently, which is the worst way to pass."""
+    with pytest.raises(ValueError, match="at least one judge"):
+        Jury([])


### PR DESCRIPTION
feat(judge): a jury, so a second grader is composed rather than wrapped

An agent has more than one reason to send an answer back, and they are not the same kind of thing:
completeness is a model's judgement, while "did it cite a page it never opened" is arithmetic over
the run's own tool calls. Expressing the second as a decorator around the first works and reads
badly — the panel is hidden inside a constructor, its order is fixed at the definition, and the
caller cannot see who is grading.

`Jury([graded, cited])` says it where the panel is assembled. It passes only if every member passes,
keeps every objection (a dropped one costs a turn spent on half the problem), and runs the members
concurrently since one of them is usually a model call.

An outage propagates instead of being swallowed: the loop already has a fail-open path, and a grader
that is down must not read as a grader that approved. An empty panel raises — a jury of nobody would
pass everything, silently.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01TsDY2sCSfY6MTfUqFkMKeC
