### PR TITLE
Судья видит вызов инструмента целиком, а не первые 200 символов

### DIFF
--- a/baski/agents/message_history.py
+++ b/baski/agents/message_history.py
@@ -238,6 +238,11 @@ class InMemoryMessageHistory(MessageHistory):
     def format_for_judge(self) -> str:
         """Compact transcript for the completeness judge: user/assistant text + `[tool] name(args)` markers.
 
+        Call arguments are rendered whole. A clipped payload cannot be told apart from an argument that
+        was never passed, so the judge grades a guess: it read a cut-off `create_estimate(...)` as a
+        missing required field and ordered the agent to call the tool again — two work orders per call in
+        production. The transcript's real bound is this history's token budget, not a per-call limit.
+
         Tool *results* are omitted on purpose — the judge grades completeness from what was asked, said,
         and run, not from raw tool output (that bloats the prompt and pulls the judge into fact-checking).
         """
@@ -253,7 +258,7 @@ class InMemoryMessageHistory(MessageHistory):
                         lines.append(f"[{message['role']}] {_block_field(block, 'text')}")
                     elif btype == "tool_use":
                         args = _block_field(block, "input")
-                        rendered = json.dumps(args, ensure_ascii=False)[:200] if args else ""
+                        rendered = json.dumps(args, ensure_ascii=False) if args else ""
                         lines.append(f"[tool] {_block_field(block, 'name')}({rendered})")
         return "\n".join(lines)
 

--- a/tests/agents/test_message_history.py
+++ b/tests/agents/test_message_history.py
@@ -1,0 +1,33 @@
+"""The judge must see the whole tool call, or it grades a guess.
+
+`format_for_judge` clipped every call's arguments at 200 characters. A real `create_estimate` call
+serializes to ~1100, so the judge saw a payload with the last key gone and the JSON unclosed, drew the
+only conclusion available — the work is unfinished — and its feedback went back to the agent as an
+instruction. Three production runs re-called the tool and opened a second work order for one phone call
+(ShopMonkey #4231+#4232, #4249+#4250, #4266+#4267). Two of those verdicts said outright that the payload
+they were shown was truncated.
+"""
+
+from anthropic.types import ToolUseBlock
+
+from baski.agents.message_history import InMemoryMessageHistory
+
+
+def test_judge_sees_the_last_argument_of_a_long_call() -> None:
+    note = "Customer reports a grinding noise from the front left wheel under braking. " * 12
+    call = ToolUseBlock(
+        id="toolu_01",
+        type="tool_use",
+        name="create_estimate",
+        input={"complaint": note, "vehicle": "2015 Honda Civic", "note": note, "authorized": True},
+    )
+    history = InMemoryMessageHistory()
+    with history as turn:
+        turn.add_user_text("Book the estimate")
+        turn.add_assistant([call])
+
+    transcript = history.format_for_judge()
+
+    assert len(transcript) > 1_000, "a call this size must not be summarized away"
+    assert '"authorized": true' in transcript, "the last argument is what the judge checks was passed"
+    assert transcript.endswith("})"), "an unclosed payload reads to the judge as a malformed call"


### PR DESCRIPTION
## Что было сломано

`InMemoryMessageHistory.format_for_judge` резал аргументы каждого вызова инструмента на 200 символах:

```python
rendered = json.dumps(args, ensure_ascii=False)[:200] if args else ""
```

Реальный вызов `create_estimate` в clarity-auto-care сериализуется в 1000–1100 символов. Судья завершённости видел payload без последнего ключа, со строкой, оборванной посередине, и незакрытой скобкой — и делал единственный доступный ему вывод: работа не доделана. Его фидбек уходит агенту как инструкция, агент подчиняется и вызывает инструмент повторно.

```mermaid
sequenceDiagram
    participant A as Агент
    participant J as Судья завершённости
    participant SM as ShopMonkey
    A->>SM: create_estimate (payload ≈ 1100 символов)
    SM-->>A: заказ-наряд #4231
    A->>J: работа закончена
    Note over J: в транскрипте вызов обрезан до 200:<br/>note отсутствует, скобка не закрыта
    J-->>A: "call create_estimate again, ensuring<br/>you include the `note` parameter"
    A->>SM: create_estimate (те же аргументы)
    SM-->>A: заказ-наряд #4232
    Note over SM: два заказ-наряда на один звонок
```

Три прогона из 53 успешных: пары #4231+#4232, #4249+#4250, #4266+#4267. Вердикты в трейсах `a6ac553c` и `67d3c209` прямым текстом жалуются на обрезанный payload («ensuring you pass the complete, **non-truncated** `complaint`», «the JSON payload are fully closed and **not truncated**») — судья не ошибался в рассуждении, ему дали негодные данные. Из мыслей агента в трейсе `c3f029d7`: «вызвать create_estimate снова — значит создать дубликат, но проверка полноты меня к этому толкает».

## Что изменилось

Лимит на вызов убран — аргументы идут в транскрипт целиком. Отдельный бюджет здесь не нужен и не был бюджетом: объём транскрипта уже ограничен токен-лимитом самой `MessageHistory`, а 200 символов на вызов скрывали ровно тот факт, который судья проверяет — был ли передан обязательный аргумент. Правка общая, не про `create_estimate`: любой инструмент с длинными аргументами страдал так же.

Тест `tests/agents/test_message_history.py` — до этого PR `format_for_judge` не упоминался в тестах baski ни разу.

## Проверки

| Команда | Результат |
|---|---|
| `uv run pytest tests/agents/test_message_history.py` на коде **до** правки | падает: `assert 249 > 1000` — транскрипт обрывается на `...front left wheel under br` |
| `make ci` (ruff format + ruff check + baski_lint + mypy 88 файлов + pytest) | зелёный, 87 тестов |

## Риск и откат

Транскрипт судьи растёт на длину аргументов — это входные токены каждой проверки завершённости. Судья и так получает весь текст сообщений без ограничений; вызовы инструментов были единственным местом с отдельным лимитом. Откат — revert одного коммита, поведение вернётся к обрезке.

## Что осталось за рамками

Идемпотентность `create_estimate` уже решена на стороне clarity-auto-care: повторный вызов возвращает созданный заказ и второго POST не делает. Эта правка убирает лишний ход агента, ложный вердикт и трату токенов, а не саму защиту — её трогать не нужно.
